### PR TITLE
Fix specular uniform type mismatch

### DIFF
--- a/BasicLightingRenderer.cs
+++ b/BasicLightingRenderer.cs
@@ -74,7 +74,7 @@ namespace RenderMaster
             Logger.Log("Current Model: " + model.modelPath, LogLevel.Info);
 
 
-            shader.SetUniformVec3("material.specular", new Vector3(0.5f, 0.5f, 0.5f));
+            shader.SetUniformVec3("material.specularTint", new Vector3(0.5f, 0.5f, 0.5f));
             shader.SetUniformFloat("material.shininess", 32.0f);
 
 

--- a/EngineBaseDir/Shaders/material_based_lighting.frag
+++ b/EngineBaseDir/Shaders/material_based_lighting.frag
@@ -16,11 +16,12 @@ struct Light {
 };
 uniform Light light;
 
-struct Material { 
+struct Material {
     sampler2D diffuse;  // Diffuse texture map
-    sampler2D specular;      // Specular reflection color
+    sampler2D specular;      // Specular reflection map
     float shininess;    // Shininess factor for specular reflection
-}; 
+    vec3 specularTint;  // Specular color tint
+};
 
 uniform Material material;
 
@@ -43,7 +44,7 @@ void main()
     vec3 viewDir = normalize(viewPos - FragPos);
     vec3 reflectDir = reflect(-lightDir, norm);
     float spec = pow(max(dot(viewDir, reflectDir), 0.0), material.shininess);
-    vec3 specular = light.specular * spec * vec3(texture(material.specular, TexCoord));
+    vec3 specular = light.specular * spec * vec3(texture(material.specular, TexCoord)) * material.specularTint;
 
     // FINAL COLOR COMPUTATION
     vec3 result = ambient + diffuse + specular;


### PR DESCRIPTION
## Summary
- Rename material.specular uniform to material.specularTint to avoid sampler2D conflict
- Add specularTint field to Material shader struct and apply in specular lighting

## Testing
- `dotnet build RenderMaster.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a8fea3b29483269cfd897224ea0bb5