### PR TITLE
Fix VAO binding order to ensure index buffer sticks

### DIFF
--- a/VertexConfiguration.cs
+++ b/VertexConfiguration.cs
@@ -70,12 +70,11 @@ namespace RenderMaster
 
         public void Bind()
         {
-            GL.BindBuffer(BufferTarget.ArrayBuffer, VBO);
+            GL.BindVertexArray(VAO);
             if (indexBuffer != -1)
             {
                 GL.BindBuffer(BufferTarget.ElementArrayBuffer, indexBuffer);
             }
-            GL.BindVertexArray(VAO);
         }
 
 


### PR DESCRIPTION
## Summary
- Bind the VAO before binding the element buffer so the index buffer binding is stored with the VAO
- Remove unnecessary VBO bind which could override other state

## Testing
- `dotnet build RenderMaster.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68aa304a98b08326b68cb8e3d8cbf4aa