### PR TITLE
Implement fixed-step update loop and split UI rendering

### DIFF
--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -19,6 +19,9 @@ public class Game : GameWindow
     Scene mainScene;
     OpenGLStateStack openGLState;
 
+    const double FixedUpdateRate = 1.0 / 60.0;
+    double updateAccumulator = 0.0;
+
     public Game(int width, int height, string title) : base(GameWindowSettings.Default, new NativeWindowSettings()
     {
 
@@ -75,12 +78,27 @@ public class Game : GameWindow
         openGLState.PopState();
     }
 
+    protected override void OnUpdateFrame(FrameEventArgs args)
+    {
+        base.OnUpdateFrame(args);
+
+        updateAccumulator += args.Time;
+
+        while (updateAccumulator >= FixedUpdateRate)
+        {
+            mainScene.Update(FixedUpdateRate);
+            updateAccumulator -= FixedUpdateRate;
+        }
+
+        userInterface.Update(args, this.mainScene.camera);
+    }
+
     protected override void OnRenderFrame(FrameEventArgs args)
     {
         openGLState.PushState();
         mainScene.RenderScene(args);
         userInterface.Bind();
-        userInterface.Render(args, this.mainScene.camera);
+        userInterface.Render();
         userInterface.Unbind();
         SwapBuffers();
 

--- a/src/Scene/Scene.cs
+++ b/src/Scene/Scene.cs
@@ -46,6 +46,13 @@ public class Scene
 
 
 
+    public void Update(double deltaTime)
+    {
+        // Placeholder for simulation updates
+    }
+
+
+
 
     public void RenderScene(FrameEventArgs args)
     {


### PR DESCRIPTION
## Summary
- Add fixed timestep accumulator and `OnUpdateFrame` handler to drive simulation updates
- Split ImGui UI logic into update and render passes for clearer separation of concerns
- Stub out a scene `Update` method for non-graphics per-frame logic

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68aac17663388326866748210290684b