### PR TITLE
refactor: adopt primary constructors

### DIFF
--- a/src/Core/Logger.cs
+++ b/src/Core/Logger.cs
@@ -75,13 +75,13 @@ public class ConsoleLogger : ILogger
     }
 }
 
-public class EngineDirFileLogger : ILogger
+public class EngineDirFileLogger() : ILogger
 {
     string logDirectory = EngineConfig.LoggingDirectory;
 
     StreamWriter sw;
 
-    public EngineDirFileLogger()
+    public EngineDirFileLogger
     {
 
         if (!Directory.Exists(logDirectory))

--- a/src/Core/TimingAspect.cs
+++ b/src/Core/TimingAspect.cs
@@ -49,18 +49,12 @@ public class MeasureExecutionTimeAttribute : Attribute
 {
 }
 
-public class CircularBuffer<T>
+public class CircularBuffer<T>(int size)
 {
-    private readonly int _size;
-    private readonly T[] _values;
+    private readonly int _size = size;
+    private readonly T[] _values = new T[size];
     private int _start;
     private int _count;
-
-    public CircularBuffer(int size)
-    {
-        _size = size;
-        _values = new T[size];
-    }
 
     public void Add(T value)
     {

--- a/src/Graphics/Configurations/VertColorNormalConfiguration.cs
+++ b/src/Graphics/Configurations/VertColorNormalConfiguration.cs
@@ -2,9 +2,8 @@
 
 namespace RenderMaster;
 
-public class VertColorNormalConfiguration : VertexConfiguration
+public class VertColorNormalConfiguration(float[] vertices) : VertexConfiguration(vertices)
 {
-    public VertColorNormalConfiguration(float[] vertices) : base(vertices) { }
 
     protected override void SetupAttributes()
     {

--- a/src/Graphics/Configurations/VertColorNormalUVConfiguration.cs
+++ b/src/Graphics/Configurations/VertColorNormalUVConfiguration.cs
@@ -4,11 +4,10 @@ namespace RenderMaster;
 
 
 
-public class VertColorNormalUVConfiguration : VertexConfiguration
+public class VertColorNormalUVConfiguration(float[] vertices) : VertexConfiguration(vertices)
 {
 
 
-    public VertColorNormalUVConfiguration(float[] vertices) : base(vertices) { }
 
 
 

--- a/src/Graphics/Configurations/VertColorTextureConfiguration.cs
+++ b/src/Graphics/Configurations/VertColorTextureConfiguration.cs
@@ -2,9 +2,8 @@
 
 namespace RenderMaster;
 
-public class VertColorTextureConfiguration : VertexConfiguration
+public class VertColorTextureConfiguration(float[] vertices) : VertexConfiguration(vertices)
 {
-    public VertColorTextureConfiguration(float[] vertices) : base(vertices) { }
 
     protected override void SetupAttributes()
     {

--- a/src/Graphics/Rendering/ATexture.cs
+++ b/src/Graphics/Rendering/ATexture.cs
@@ -8,13 +8,9 @@ using StbImageSharp;
 namespace RenderMaster;
 
 
-public abstract class ATexture
+public abstract class ATexture(string path)
 {
-    public ImageResult textureImage;
-    public ATexture(string path)
-    {
-        this.textureImage = loadImageFromPath(path);
-    }
+    public ImageResult textureImage = loadImageFromPath(path);
 
     public abstract void Bind();
 

--- a/src/Graphics/Rendering/BasicImageTexture.cs
+++ b/src/Graphics/Rendering/BasicImageTexture.cs
@@ -4,19 +4,15 @@ using RenderMaster.Engine;
 
 namespace RenderMaster;
 
-public class BasicImageTexture : ATexture
+public class BasicImageTexture(string path, TextureUnit unit) : ATexture(path)
 {
     public int TextureId { get; private set; }
-    public TextureUnit textureUnit;
-    public String texturePath = "";
+    public TextureUnit textureUnit = unit;
+    public String texturePath = path;
 
 
-    public BasicImageTexture(string path, TextureUnit unit) : base(path)
+    public BasicImageTexture
     {
-        this.texturePath = path;
-        this.textureUnit = unit;
-
-
         GL.ActiveTexture(textureUnit);
 
 

--- a/src/Graphics/Rendering/BasicLightingRenderer.cs
+++ b/src/Graphics/Rendering/BasicLightingRenderer.cs
@@ -9,21 +9,12 @@ namespace RenderMaster;
 
 
 
-public class BasicLightingRenderer : IRenderer
+public class BasicLightingRenderer(Model model, BasicTexturedShader shader) : IRenderer
 {
-    private Model model;
-    private BasicTexturedShader shader;
-    private VertexConfiguration vertexConfiguration;
+    private Model model = model;
+    private BasicTexturedShader shader = shader;
+    private VertexConfiguration vertexConfiguration = model.vertexConfiguration;
     private double timeSoFar;
-
-
-
-    public BasicLightingRenderer(Model model, BasicTexturedShader shader)
-    {
-        this.model = model;
-        this.shader = shader;
-        this.vertexConfiguration = model.vertexConfiguration;
-    }
 
 
 

--- a/src/Graphics/Rendering/BasicTexturedModelRenderer.cs
+++ b/src/Graphics/Rendering/BasicTexturedModelRenderer.cs
@@ -4,21 +4,12 @@ using OpenTK.Windowing.Common;
 
 namespace RenderMaster;
 
-public class BasicTexturedModelRenderer : IRenderer
+public class BasicTexturedModelRenderer(Model model, BasicTexturedShader shader, BasicImageTexture texture) : IRenderer
 {
-    private Model model;
-    private BasicTexturedShader shader;
-    private BasicImageTexture texture;
-    private VertexConfiguration vertexConfiguration;
-
-    public BasicTexturedModelRenderer(Model model, BasicTexturedShader shader, BasicImageTexture texture)
-    {
-        this.model = model;
-        this.shader = shader;
-        this.texture = texture;
-        this.vertexConfiguration = model.vertexConfiguration;
-
-    }
+    private Model model = model;
+    private BasicTexturedShader shader = shader;
+    private BasicImageTexture texture = texture;
+    private VertexConfiguration vertexConfiguration = model.vertexConfiguration;
 
     [MeasureExecutionTime]
     public void Render(FrameEventArgs e, Camera camera)

--- a/src/Graphics/Rendering/BasicTexturedShader.cs
+++ b/src/Graphics/Rendering/BasicTexturedShader.cs
@@ -6,11 +6,11 @@ namespace RenderMaster;
 
 
 
-public class BasicTexturedShader : AShader
+public class BasicTexturedShader(string vertexPath, string fragmentPath) : AShader
 {
 
 
-    public BasicTexturedShader(string vertexPath, string fragmentPath)
+    public BasicTexturedShader
     {
         Load(vertexPath, fragmentPath);
     }

--- a/src/Graphics/State/OpenGLState.cs
+++ b/src/Graphics/State/OpenGLState.cs
@@ -5,55 +5,55 @@ using OpenTK.Graphics.OpenGL;
 namespace RenderMaster;
 
 // captures a snapshot of key OpenGL state for restoration
-public class OpenGLStateSnapshot
+public class OpenGLStateSnapshot()
 {
 
-public bool DepthTestEnabled { get; private set; }
-public bool CullFaceEnabled { get; private set; }
-public PolygonMode PolygonMode { get; private set; }
-public Rectangle Viewport { get; private set; }
-public DepthFunction DepthFunc { get; private set; }
-public BlendingFactorSrc BlendSrc { get; private set; }
-public BlendingFactorDest BlendDest { get; private set; }
-public CullFaceMode CullFaceMode { get; private set; }
-public FrontFaceDirection FrontFace { get; private set; }
+    public bool DepthTestEnabled { get; private set; }
+    public bool CullFaceEnabled { get; private set; }
+    public PolygonMode PolygonMode { get; private set; }
+    public Rectangle Viewport { get; private set; }
+    public DepthFunction DepthFunc { get; private set; }
+    public BlendingFactorSrc BlendSrc { get; private set; }
+    public BlendingFactorDest BlendDest { get; private set; }
+    public CullFaceMode CullFaceMode { get; private set; }
+    public FrontFaceDirection FrontFace { get; private set; }
 
 
-public OpenGLStateSnapshot()
-{
+    public OpenGLStateSnapshot
+    {
 
-    DepthTestEnabled = GL.IsEnabled(EnableCap.DepthTest);
-
-
-    CullFaceEnabled = GL.IsEnabled(EnableCap.CullFace);
+        DepthTestEnabled = GL.IsEnabled(EnableCap.DepthTest);
 
 
-    GL.GetInteger(GetPName.PolygonMode, out int polygonMode);
-    PolygonMode = (PolygonMode)polygonMode;
+        CullFaceEnabled = GL.IsEnabled(EnableCap.CullFace);
 
 
-    int[] viewport = new int[4];
-    GL.GetInteger(GetPName.Viewport, viewport);
-    Viewport = new Rectangle(viewport[0], viewport[1], viewport[2], viewport[3]);
+        GL.GetInteger(GetPName.PolygonMode, out int polygonMode);
+        PolygonMode = (PolygonMode)polygonMode;
 
 
-    GL.GetInteger(GetPName.DepthFunc, out int depthFunc);
-    DepthFunc = (DepthFunction)depthFunc;
+        int[] viewport = new int[4];
+        GL.GetInteger(GetPName.Viewport, viewport);
+        Viewport = new Rectangle(viewport[0], viewport[1], viewport[2], viewport[3]);
 
 
-    GL.GetInteger(GetPName.BlendSrc, out int blendSrc);
-    BlendSrc = (BlendingFactorSrc)blendSrc;
-    GL.GetInteger(GetPName.BlendDst, out int blendDest);
-    BlendDest = (BlendingFactorDest)blendDest;
+        GL.GetInteger(GetPName.DepthFunc, out int depthFunc);
+        DepthFunc = (DepthFunction)depthFunc;
 
 
-    GL.GetInteger(GetPName.CullFaceMode, out int cullFaceMode);
-    CullFaceMode = (CullFaceMode)cullFaceMode;
+        GL.GetInteger(GetPName.BlendSrc, out int blendSrc);
+        BlendSrc = (BlendingFactorSrc)blendSrc;
+        GL.GetInteger(GetPName.BlendDst, out int blendDest);
+        BlendDest = (BlendingFactorDest)blendDest;
 
 
-    GL.GetInteger(GetPName.FrontFace, out int frontFace);
-    FrontFace = (FrontFaceDirection)frontFace;
-}
+        GL.GetInteger(GetPName.CullFaceMode, out int cullFaceMode);
+        CullFaceMode = (CullFaceMode)cullFaceMode;
+
+
+        GL.GetInteger(GetPName.FrontFace, out int frontFace);
+        FrontFace = (FrontFaceDirection)frontFace;
+    }
 
 
 

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -10,7 +10,7 @@ using RenderMaster.Engine;
 
 namespace RenderMaster;
 
-public class Game : GameWindow
+public class Game(int width, int height, string title) : GameWindow(GameWindowSettings.Default, new NativeWindowSettings() { ClientSize = (width, height), Title = title })
 {
 
 
@@ -22,12 +22,7 @@ public class Game : GameWindow
     const double FixedUpdateRate = 1.0 / 60.0;
     double updateAccumulator = 0.0;
 
-    public Game(int width, int height, string title) : base(GameWindowSettings.Default, new NativeWindowSettings()
-    {
-
-        ClientSize = (width, height),
-        Title = title
-    })
+    public Game
     {
         this.mainScene = new Scene("main testing scene", width, height);
 

--- a/src/Scene/Camera.cs
+++ b/src/Scene/Camera.cs
@@ -6,11 +6,11 @@ namespace RenderMaster;
 
 
 
-public class Camera
+public class Camera(Vector3 position, Vector3 lookingAt, float fieldOfView, float aspectRatio, float nearPlane, float farPlane)
 {
 
-    public Vector3 Position { get; set; }
-    public Vector3 LookingAt { get; set; }
+    public Vector3 Position { get; set; } = position;
+    public Vector3 LookingAt { get; set; } = lookingAt;
     public Matrix4 View { get; set; }
     public Matrix4 Projection { get; set; }
 
@@ -19,12 +19,8 @@ public class Camera
 
 
 
-    public Camera(Vector3 position, Vector3 lookingAt, float fieldOfView, float aspectRatio, float nearPlane, float farPlane)
+    public Camera
     {
-        Position = position;
-        LookingAt = lookingAt;
-
-
         UpdateViewMatrix();
 
 

--- a/src/Scene/Material.cs
+++ b/src/Scene/Material.cs
@@ -6,15 +6,10 @@ using System.Threading.Tasks;
 
 namespace RenderMaster;
 
-public class Material
+public class Material(BasicImageTexture diffuse, BasicImageTexture specular)
 {
-    public BasicImageTexture Diffuse;
-    public BasicImageTexture Specular;
-
-    public Material(BasicImageTexture diffuse, BasicImageTexture specular) {
-        this.Diffuse = diffuse;
-        this.Specular = specular;
-    }
+    public BasicImageTexture Diffuse = diffuse;
+    public BasicImageTexture Specular = specular;
 
     public bool BindAllTextures()
     {

--- a/src/Scene/Model.cs
+++ b/src/Scene/Model.cs
@@ -8,15 +8,15 @@ namespace RenderMaster;
 
 
 
-public class Model : IModel // represents a renderable 3D model
+public class Model(VertType vertType, ModelShaderType modelShaderType, string modelPath, Material material) : IModel // represents a renderable 3D model
 {
-    VertType vertType;
-    ModelShaderType modelShaderType;
+    VertType vertType = vertType;
+    ModelShaderType modelShaderType = modelShaderType;
     public VertexConfiguration vertexConfiguration;
-    public string modelPath;
+    public string modelPath = modelPath;
     string? imagePath;
 
-    public Material material;
+    public Material material = material;
 
     public float[] verts;
     public Vector3 Position { get; set; }
@@ -34,22 +34,11 @@ public class Model : IModel // represents a renderable 3D model
 
 
 
-    public Model(VertType vertType, ModelShaderType modelShaderType, string modelPath, Material material)
+    public Model
     {
-        this.vertType = vertType;
-        this.modelPath = modelPath;
-        this.verts = loadVerticesFromPath(modelPath);
-        this.material = material;
-
-
-
-        this.vertexConfiguration = new VertColorNormalUVConfiguration(this.verts);
-
-        this.modelShaderType = modelShaderType;
-
-
-
-        this.renderer = new BasicLightingRenderer(
+        verts = loadVerticesFromPath(modelPath);
+        vertexConfiguration = new VertColorNormalUVConfiguration(verts);
+        renderer = new BasicLightingRenderer(
             this,
             new BasicTexturedShader(Path.Combine(EngineConfig.ShaderDirectory, "material_based_lighting.vert"), Path.Combine(EngineConfig.ShaderDirectory, "material_based_lighting.frag"))
             );

--- a/src/Scene/Scene.cs
+++ b/src/Scene/Scene.cs
@@ -6,29 +6,20 @@ namespace RenderMaster;
 
 
 
-public class Scene
+public class Scene(string name, int width, int height)
 {
 
-    string name;
+    string name = name;
 
 
-    public List<Model> sceneModels;
+    public List<Model> sceneModels = new();
 
 
-    public Camera camera;
-
-
-
-
-    public Scene(string name, int width, int height)
-    {
-        this.name = name;
-        this.sceneModels = new List<Model>();
+    public Camera camera = new Camera(new Vector3(2, 0, 0), new Vector3(0, 0, 0), 0.8f,(float)width / (float)height, 1, 100000000);
 
 
 
-        this.camera = new Camera(new Vector3(2, 0, 0), new Vector3(0, 0, 0), 0.8f,(float)width / (float)height, 1, 100000000);
-    }
+
 
 
 

--- a/src/UI/ImGuiBufferConfig.cs
+++ b/src/UI/ImGuiBufferConfig.cs
@@ -4,9 +4,8 @@ using System.Runtime.CompilerServices;
 
 namespace RenderMaster;
 
-public class ImGuiBufferConfig : VertexConfiguration
+public class ImGuiBufferConfig() : VertexConfiguration
 {
-    public ImGuiBufferConfig() : base() { }
 
     protected override void SetupAttributes()
     {


### PR DESCRIPTION
## Summary
- refactor multiple engine classes to use C# primary constructors, reducing boilerplate
- simplify texture, rendering, and logging helpers with constructor parameters
- modernize Game setup by leveraging primary constructor field initialization

## Testing
- `dotnet build RenderMaster.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68aac5fdf0488326aa79505236fc1691