### PR TITLE
Extract legacy model loader

### DIFF
--- a/src/Scene/IModelLoader.cs
+++ b/src/Scene/IModelLoader.cs
@@ -1,0 +1,6 @@
+namespace RenderMaster;
+
+public interface IModelLoader
+{
+    float[] loadModel(string AssetPath);
+}

--- a/src/Scene/LegacyModelLoader.cs
+++ b/src/Scene/LegacyModelLoader.cs
@@ -1,0 +1,33 @@
+namespace RenderMaster;
+
+public class LegacyModelLoader : IModelLoader
+{
+    public float[] loadModel(string AssetPath)
+    {
+        List<float> vertices = new List<float>();
+
+        using (var stream = File.OpenRead(AssetPath))
+        using (var reader = new StreamReader(stream))
+        {
+            int totalLines = File.ReadLines(AssetPath).Count();
+            int currentLine = 0;
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                currentLine++;
+                string[] parts = line.Split(' ');
+
+                if (currentLine % 5 == 0)
+                {
+                }
+
+                for (int i = 0; i < parts.Length; i++)
+                {
+                    vertices.Add(float.Parse(parts[i]));
+                }
+            }
+        }
+
+        return vertices.ToArray();
+    }
+}

--- a/src/Scene/Model.cs
+++ b/src/Scene/Model.cs
@@ -38,7 +38,7 @@ public class Model : IModel // represents a renderable 3D model
     {
         this.vertType = vertType;
         this.modelPath = modelPath;
-        this.verts = loadVerticesFromPath(modelPath);
+        this.verts = new LegacyModelLoader().loadModel(modelPath);
         this.material = material;
 
 
@@ -70,39 +70,6 @@ public class Model : IModel // represents a renderable 3D model
     }
 
 
-
-    private float[] loadVerticesFromPath(string path) // read whitespace-separated floats
-    {
-        List<float> vertices = new List<float>();
-
-
-        using (var stream = File.OpenRead(path))
-        using (var reader = new StreamReader(stream))
-        {
-
-            int totalLines = File.ReadLines(path).Count();
-            int currentLine = 0;
-            string line;
-            while ((line = reader.ReadLine()) != null)
-            {
-                currentLine++;
-                string[] parts = line.Split(' ');
-
-
-                if (currentLine % 5 == 0)
-                {
-                }
-
-
-                for (int i = 0; i < parts.Length; i++)
-                {
-                    vertices.Add(float.Parse(parts[i]));
-                }
-            }
-        }
-
-        return vertices.ToArray();
-    }
 }
 
 


### PR DESCRIPTION
## Summary
- add `IModelLoader` interface
- move vertex file parsing into `LegacyModelLoader`
- update `Model` to use `LegacyModelLoader` for loading vertices

## Testing
- `dotnet build RenderMaster.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68aac85aab788326b2ab13deb8b6d4bd