### PR TITLE
refactor: switch to DSA texture creation

### DIFF
--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -38,8 +38,8 @@ public class Game : GameWindow
         
         this.mainScene = new Scene("main testing scene", width, height);
 
-        BasicImageTexture diffuse = new BasicImageTexture(Path.Combine(EngineConfig.ModelDirectory, "TableAndLamp\\table.jpg"));
-        BasicImageTexture specular = new BasicImageTexture(Path.Combine(EngineConfig.ModelDirectory, "TableAndLamp\\table_specular.jpg"));
+        BasicImageTexture diffuse = new BasicImageTexture(Path.Combine(EngineConfig.ModelDirectory, "TableAndLamp\\table.jpg"), TextureUnit.Texture0);
+        BasicImageTexture specular = new BasicImageTexture(Path.Combine(EngineConfig.ModelDirectory, "TableAndLamp\\table_specular.jpg"), TextureUnit.Texture1);
 
         var tableMaterial = new Material(diffuse, specular);
 


### PR DESCRIPTION
## Summary
- refactor BasicImageTexture to use OpenGL direct state access for parameter setup and uploads
- bind textures via BindTextureUnit and assign explicit texture units in program setup

## Testing
- `dotnet build RenderMaster.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b2118d5c888326a13fb81fd88c8074