### PR TITLE
Refactor texture bindings to use DSA and stack-based cache

### DIFF
--- a/src/Graphics/Rendering/BasicLightingRenderer.cs
+++ b/src/Graphics/Rendering/BasicLightingRenderer.cs
@@ -66,11 +66,15 @@ public class BasicLightingRenderer : IRenderer
         var specularMapTexture = model.material.Specular;
 
         model.material.BindAllTextures();
-        shader.SetSampler2D("material.diffuse", diffuseMapTexture.textureUnit);
-        shader.SetSampler2D("material.specular", specularMapTexture.textureUnit);
+
+        var diffuseUnit = (TextureUnit)((int)TextureUnit.Texture0 + diffuseMapTexture.BoundUnit.GetValueOrDefault());
+        var specularUnit = (TextureUnit)((int)TextureUnit.Texture0 + specularMapTexture.BoundUnit.GetValueOrDefault());
+
+        shader.SetSampler2D("material.diffuse", diffuseUnit);
+        shader.SetSampler2D("material.specular", specularUnit);
 
 
-        Logger.Log("Inside Renderer: Current texture unit: " + diffuseMapTexture.textureUnit + " Current Model: " + model.modelPath, LogLevel.Info);
+        Logger.Log("Inside Renderer: Current texture unit: " + diffuseMapTexture.BoundUnit + " Current Model: " + model.modelPath, LogLevel.Info);
         Logger.Log("Current Model: " + model.modelPath, LogLevel.Info);
 
 

--- a/src/Graphics/State/TextureCache.cs
+++ b/src/Graphics/State/TextureCache.cs
@@ -1,6 +1,4 @@
-﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using OpenTK.Graphics.OpenGL4;
 using RenderMaster.Engine;
 
@@ -8,12 +6,17 @@ namespace RenderMaster;
 
 public class TextureCache
 {
-    private static TextureCache instance;
-    private Dictionary<string, BasicImageTexture> textureCache = new Dictionary<string, BasicImageTexture>();
+    private static TextureCache? instance;
+    private readonly Dictionary<string, BasicImageTexture> textureCache = new();
+    private readonly Stack<int> availableUnits = new();
 
-
-    private TextureCache() { }
-
+    private TextureCache()
+    {
+        for (int i = 31; i >= 0; i--)
+        {
+            availableUnits.Push(i);
+        }
+    }
 
     public static TextureCache Instance
     {
@@ -27,108 +30,54 @@ public class TextureCache
         }
     }
 
-
-    private int currentTextureUnit = 0;
-
-
-    public TextureUnit GetTextureUnitForInt(int i)
+    public void AcquireUnit(BasicImageTexture texture)
     {
-        switch (i)
+        if (texture.BoundUnit.HasValue)
         {
-            case 0:
-                return TextureUnit.Texture0;
-            case 1:
-                return TextureUnit.Texture1;
-            case 2:
-                return TextureUnit.Texture2;
-            case 3:
-                return TextureUnit.Texture3;
-            case 4:
-                return TextureUnit.Texture4;
-            case 5:
-                return TextureUnit.Texture5;
-            case 6:
-                return TextureUnit.Texture6;
-            case 7:
-                return TextureUnit.Texture7;
-            case 8:
-                return TextureUnit.Texture8;
-            case 9:
-                return TextureUnit.Texture9;
-            case 10:
-                return TextureUnit.Texture10;
-            case 11:
-                return TextureUnit.Texture11;
-            case 12:
-                return TextureUnit.Texture12;
-            case 13:
-                return TextureUnit.Texture13;
-            case 14:
-                return TextureUnit.Texture14;
-            case 15:
-                return TextureUnit.Texture15;
-            case 16:
-                return TextureUnit.Texture16;
-            case 17:
-                return TextureUnit.Texture17;
-            case 18:
-                return TextureUnit.Texture18;
-            case 19:
-                return TextureUnit.Texture19;
-            case 20:
-                return TextureUnit.Texture20;
-            case 21:
-                return TextureUnit.Texture21;
-            case 22:
-                return TextureUnit.Texture22;
-            case 23:
-                return TextureUnit.Texture23;
-            case 24:
-                return TextureUnit.Texture24;
-            case 25:
-                return TextureUnit.Texture25;
-            case 26:
-                return TextureUnit.Texture26;
-            case 27:
-                return TextureUnit.Texture27;
-            case 28:
-                return TextureUnit.Texture28;
-            case 29:
-                return TextureUnit.Texture29;
-            case 30:
-                return TextureUnit.Texture30;
-            case 31:
-                return TextureUnit.Texture31;
-            default:
-                return TextureUnit.Texture0;
+            return;
+        }
+
+        if (availableUnits.Count > 0)
+        {
+            texture.BoundUnit = availableUnits.Pop();
+        }
+        else
+        {
+            Logger.Log("No available texture units", LogLevel.Error);
         }
     }
 
+    public void ReleaseUnit(BasicImageTexture texture)
+    {
+        if (texture.BoundUnit.HasValue)
+        {
+            availableUnits.Push(texture.BoundUnit.Value);
+            texture.BoundUnit = null;
+        }
+    }
 
     public BasicImageTexture GetTexture(string path)
     {
-        if (!textureCache.ContainsKey(path))
+        if (!textureCache.TryGetValue(path, out var texture))
         {
-
-            var textureUnit = GetTextureUnitForInt(currentTextureUnit);
-            var texture = new BasicImageTexture(path, textureUnit);
+            texture = new BasicImageTexture(path);
             textureCache[path] = texture;
-            this.currentTextureUnit += 1;
-
-            return texture;
-
         }
-
-        return textureCache[path];
+        return texture;
     }
-
 
     public void ClearCache()
     {
         foreach (var texture in textureCache.Values)
         {
-            GL.DeleteTexture(texture.TextureId);
+            texture.Dispose();
         }
         textureCache.Clear();
+        availableUnits.Clear();
+        for (int i = 31; i >= 0; i--)
+        {
+            availableUnits.Push(i);
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- Move BasicImageTexture to use DSA APIs and `glBindTextureUnit`
- Replace permanent unit assignments with stack-based TextureCache
- Update lighting renderer to use new transient texture unit bindings

## Testing
- `dotnet build RenderMaster.csproj` *(fails: .NET SDK 8.0 does not support target net9.0)*


------
https://chatgpt.com/codex/tasks/task_e_68b21bd3c8d88326829b1adbd09530b9