### PR TITLE
Remove logging from hot paths

### DIFF
--- a/src/Graphics/Rendering/AShader.cs
+++ b/src/Graphics/Rendering/AShader.cs
@@ -1,6 +1,5 @@
 ﻿using OpenTK.Mathematics;
 using OpenTK.Graphics.OpenGL4;
-using RenderMaster.Engine;
 
 namespace RenderMaster;
 
@@ -32,13 +31,7 @@ public abstract class AShader
 
         if (location != -1)
         {
-
             GL.UniformMatrix4(location, false, ref value);
-        }
-        else
-        {
-
-            Console.WriteLine($"Warning: Uniform '{name}' not found in shader.");
         }
     }
 
@@ -54,11 +47,6 @@ public abstract class AShader
         {
             GL.Uniform3(location, ref value);
         }
-        else
-        {
-
-            Console.WriteLine($"Warning: Uniform '{name}' not found in shader.");
-        }
     }
 
 
@@ -73,19 +61,12 @@ public abstract class AShader
         {
             GL.Uniform1(location, value);
         }
-        else
-        {
-
-            Console.WriteLine($"Warning: Uniform '{name}' not found in shader.");
-        }
     }
 
 
 
     public void SetSampler2D(string name, TextureUnit textureUnit)
     {
-        Logger.Log("Setting texture unit to " + textureUnit, LogLevel.Debug);
-
         int textureUnitOffset = (int)textureUnit - (int)TextureUnit.Texture0;
 
 

--- a/src/Graphics/Rendering/BasicImageTexture.cs
+++ b/src/Graphics/Rendering/BasicImageTexture.cs
@@ -1,6 +1,5 @@
 using System;
 using OpenTK.Graphics.OpenGL4;
-using RenderMaster.Engine;
 
 namespace RenderMaster;
 
@@ -37,7 +36,6 @@ public class BasicImageTexture : ATexture, IDisposable
 
         if (BoundUnit.HasValue)
         {
-            Logger.Log("Binding texture " + TextureId + " to texture unit " + BoundUnit + " Texture path: " + TexturePath, LogLevel.Debug);
             GL.BindTextureUnit(BoundUnit.Value, TextureId);
         }
     }
@@ -46,7 +44,6 @@ public class BasicImageTexture : ATexture, IDisposable
     {
         if (BoundUnit.HasValue)
         {
-            Logger.Log("Unbinding texture " + TextureId + " from texture unit " + BoundUnit + " Texture path: " + TexturePath, LogLevel.Debug);
             GL.BindTextureUnit(BoundUnit.Value, 0);
             TextureCache.Instance.ReleaseUnit(this);
         }

--- a/src/Graphics/Rendering/BasicLightingRenderer.cs
+++ b/src/Graphics/Rendering/BasicLightingRenderer.cs
@@ -3,7 +3,6 @@ using OpenTK.Graphics.OpenGL4;
 using OpenTK.Windowing.Common;
 using ImGuiNET;
 using System.IO;
-using RenderMaster.Engine;
 
 namespace RenderMaster;
 
@@ -74,8 +73,6 @@ public class BasicLightingRenderer : IRenderer
         shader.SetSampler2D("material.specular", specularUnit);
 
 
-        Logger.Log("Inside Renderer: Current texture unit: " + diffuseMapTexture.BoundUnit + " Current Model: " + model.modelPath, LogLevel.Info);
-        Logger.Log("Current Model: " + model.modelPath, LogLevel.Info);
 
 
         shader.SetUniformVec3("material.specularTint", new Vector3(0.5f, 0.5f, 0.5f));

--- a/src/Graphics/State/TextureCache.cs
+++ b/src/Graphics/State/TextureCache.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using OpenTK.Graphics.OpenGL4;
-using RenderMaster.Engine;
 
 namespace RenderMaster;
 
@@ -40,10 +39,6 @@ public class TextureCache
         if (availableUnits.Count > 0)
         {
             texture.BoundUnit = availableUnits.Pop();
-        }
-        else
-        {
-            Logger.Log("No available texture units", LogLevel.Error);
         }
     }
 


### PR DESCRIPTION
## Summary
- Trim noisy logging from texture binding and unbinding
- Drop per-frame renderer log statements
- Remove shader uniform and texture cache logs to streamline hot paths

## Testing
- `~/dotnet9/dotnet build RenderMaster.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b21e8c83588326be41cfb8677ca5d8