### PR TITLE
Refactor input handling and add fly camera toggle

### DIFF
--- a/src/Host/Input.cs
+++ b/src/Host/Input.cs
@@ -1,0 +1,103 @@
+using ImGuiNET;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
+using OpenTK.Windowing.GraphicsLibraryFramework;
+
+namespace RenderMaster;
+
+public class Input
+{
+    private readonly GameWindow window;
+    private readonly Camera camera;
+
+    public bool MouseGrabbed { get; private set; } = false;
+
+    public Input(GameWindow window, Camera camera)
+    {
+        this.window = window;
+        this.camera = camera;
+    }
+
+    public void Update(FrameEventArgs args)
+    {
+        if (MouseGrabbed)
+        {
+            camera.ProcessKeyboard(window.KeyboardState, (float)args.Time);
+        }
+    }
+
+    public void OnKeyDown(KeyboardKeyEventArgs e)
+    {
+        var io = ImGui.GetIO();
+        ImGuiKey key = ImGuiKeyMapper.MapOpenTKKeyToImGuiKey(e.Key);
+        io.AddKeyEvent(key, true);
+
+        io.AddKeyEvent(ImGuiKey.ModCtrl, e.Control);
+        io.AddKeyEvent(ImGuiKey.ModShift, e.Shift);
+        io.AddKeyEvent(ImGuiKey.ModAlt, e.Alt);
+        io.AddKeyEvent(ImGuiKey.ModSuper, e.Modifiers.HasFlag(KeyModifiers.Super));
+
+        if (e.Key == Keys.Z && !e.IsRepeat)
+        {
+            ToggleMouseGrab();
+        }
+    }
+
+    public void OnKeyUp(KeyboardKeyEventArgs e)
+    {
+        var io = ImGui.GetIO();
+        ImGuiKey key = ImGuiKeyMapper.MapOpenTKKeyToImGuiKey(e.Key);
+        io.AddKeyEvent(key, false);
+
+        io.AddKeyEvent(ImGuiKey.ModCtrl, e.Control);
+        io.AddKeyEvent(ImGuiKey.ModShift, e.Shift);
+        io.AddKeyEvent(ImGuiKey.ModAlt, e.Alt);
+        io.AddKeyEvent(ImGuiKey.ModSuper, e.Modifiers.HasFlag(KeyModifiers.Super));
+    }
+
+    public void OnTextInput(TextInputEventArgs e)
+    {
+        var io = ImGui.GetIO();
+        io.AddInputCharacter((uint)e.Unicode);
+    }
+
+    public void OnMouseMove(MouseMoveEventArgs e)
+    {
+        var io = ImGui.GetIO();
+        float scaleFactorY = io.DisplayFramebufferScale.Y;
+        float scaleFactorX = io.DisplayFramebufferScale.X;
+        io.MousePos = new System.Numerics.Vector2(window.MouseState.X * scaleFactorX, window.MouseState.Y * scaleFactorY);
+
+        if (MouseGrabbed)
+        {
+            camera.ProcessMouseMovement(e.DeltaX, e.DeltaY);
+        }
+    }
+
+    public void OnMouseDown(MouseButtonEventArgs e)
+    {
+        var io = ImGui.GetIO();
+        io.AddMouseButtonEvent((int)e.Button, true);
+    }
+
+    public void OnMouseUp(MouseButtonEventArgs e)
+    {
+        var io = ImGui.GetIO();
+        io.AddMouseButtonEvent((int)e.Button, false);
+    }
+
+    public void OnMouseWheel(MouseWheelEventArgs e)
+    {
+        var io = ImGui.GetIO();
+        io.AddMouseWheelEvent(e.OffsetX, e.OffsetY);
+        camera.ProcessMouseScroll(e.OffsetY);
+    }
+
+    private void ToggleMouseGrab()
+    {
+        MouseGrabbed = !MouseGrabbed;
+        window.CursorGrabbed = MouseGrabbed;
+        window.CursorVisible = !MouseGrabbed;
+    }
+}
+

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -26,6 +26,7 @@ public class Game : GameWindow
 
     PhysicsEngine physicsEngine = new PhysicsEngine();
     List<PhysicsBinding> physicsBindings = new List<PhysicsBinding>();
+    Input input;
 
     public Game(int width, int height, string title) : base(GameWindowSettings.Default, new NativeWindowSettings()
     {
@@ -35,6 +36,7 @@ public class Game : GameWindow
     })
     {
         this.mainScene = new Scene("main testing scene", width, height);
+        input = new Input(this, mainScene.camera);
 
         /* mainScene.AddModel(new Model(VertType.VertColorTexture, ModelShaderType.BasicTextured, Path.Combine(EngineConfig.ModelDirectory, "UVTest\\cyl.verttxt"), Path.Combine(EngineConfig.ModelDirectory, "UVTest\\uv_check2.png")));
            mainScene.AddModel(new Model(VertType.VertColorTexture, ModelShaderType.BasicTextured, Path.Combine(EngineConfig.ModelDirectory, "TexturedCylinder\\cylinder.verttxt"), Path.Combine(EngineConfig.ModelDirectory, "TexturedCylinder\\uv_check2.png")));
@@ -139,9 +141,9 @@ public class Game : GameWindow
 
         physicsEngine.syncModelsToPhysics(physicsBindings);
 
-        mainScene.camera.ProcessKeyboard(KeyboardState, (float)args.Time);
+        input.Update(args);
 
-        userInterface.Update(args, this.mainScene.camera);
+        userInterface.Update(args, this.mainScene.camera, input.MouseGrabbed);
     }
 
     protected override void OnRenderFrame(FrameEventArgs args)
@@ -158,67 +160,37 @@ public class Game : GameWindow
 
     protected override void OnKeyDown(KeyboardKeyEventArgs e)
     {
-        var io = ImGui.GetIO();
-
-        ImGuiKey key = ImGuiKeyMapper.MapOpenTKKeyToImGuiKey(e.Key);
-        io.AddKeyEvent(key, true);
-
-
-        io.AddKeyEvent(ImGuiKey.ModCtrl, e.Control);
-        io.AddKeyEvent(ImGuiKey.ModShift, e.Shift);
-        io.AddKeyEvent(ImGuiKey.ModAlt, e.Alt);
-
-
-        io.AddKeyEvent(ImGuiKey.ModSuper, e.Modifiers.HasFlag(KeyModifiers.Super));
+        input.OnKeyDown(e);
     }
 
     protected override void OnKeyUp(KeyboardKeyEventArgs e)
     {
-        var io = ImGui.GetIO();
-
-        ImGuiKey key = ImGuiKeyMapper.MapOpenTKKeyToImGuiKey(e.Key);
-        io.AddKeyEvent(key, false);
-
-
-        io.AddKeyEvent(ImGuiKey.ModCtrl, e.Control);
-        io.AddKeyEvent(ImGuiKey.ModShift, e.Shift);
-        io.AddKeyEvent(ImGuiKey.ModAlt, e.Alt);
-
-
-        io.AddKeyEvent(ImGuiKey.ModSuper, e.Modifiers.HasFlag(KeyModifiers.Super));
+        input.OnKeyUp(e);
     }
 
     protected override void OnTextInput(TextInputEventArgs e)
     {
-        var io = ImGui.GetIO();
-        io.AddInputCharacter((uint)e.Unicode);
+        input.OnTextInput(e);
     }
 
     protected override void OnMouseMove(MouseMoveEventArgs e)
     {
-        var io = ImGui.GetIO();
-        float scaleFactorY = io.DisplayFramebufferScale.Y;
-        float scaleFactorX = io.DisplayFramebufferScale.X;
-
-        io.MousePos = new System.Numerics.Vector2(MouseState.X * scaleFactorX, MouseState.Y * scaleFactorY);
+        input.OnMouseMove(e);
     }
 
     protected override void OnMouseDown(MouseButtonEventArgs e)
     {
-        var io = ImGui.GetIO();
-        io.AddMouseButtonEvent((int)e.Button, true);
+        input.OnMouseDown(e);
     }
 
     protected override void OnMouseUp(MouseButtonEventArgs e)
     {
-        var io = ImGui.GetIO();
-        io.AddMouseButtonEvent((int)e.Button, false);
+        input.OnMouseUp(e);
     }
 
     protected override void OnMouseWheel(MouseWheelEventArgs e)
     {
-        var io = ImGui.GetIO();
-        io.AddMouseWheelEvent(e.OffsetX, e.OffsetY);
+        input.OnMouseWheel(e);
     }
 
     protected override void OnUnload()

--- a/src/Scene/Camera.cs
+++ b/src/Scene/Camera.cs
@@ -1,94 +1,96 @@
-﻿using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Common;
 using OpenTK.Mathematics;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace RenderMaster;
 
-
-
 public class Camera
 {
-
     public Vector3 Position { get; set; }
-    public Vector3 LookingAt { get; set; }
-    public Matrix4 View { get; set; }
-    public Matrix4 Projection { get; set; }
+    public Matrix4 View { get; private set; }
+    public Matrix4 Projection { get; private set; }
 
-    Vector3 Up = new Vector3(0f, 1f, 0f);
+    public float Yaw { get; private set; }
+    public float Pitch { get; private set; }
+    public bool InvertY { get; set; } = false;
+
+    public float MovementSpeed { get; private set; } = 5f;
+    public float MouseSensitivity { get; private set; } = 0.2f;
+
+    Vector3 front = -Vector3.UnitZ;
+    Vector3 up = Vector3.UnitY;
+    Vector3 right = Vector3.UnitX;
 
     public Camera(Vector3 position, Vector3 lookingAt, float fieldOfView, float aspectRatio, float nearPlane, float farPlane)
     {
         Position = position;
-        LookingAt = lookingAt;
-
-
-        UpdateViewMatrix();
-
-
+        front = Vector3.Normalize(lookingAt - position);
+        Yaw = MathHelper.RadiansToDegrees(MathF.Atan2(front.Z, front.X));
+        Pitch = MathHelper.RadiansToDegrees(MathF.Asin(front.Y));
+        UpdateCameraVectors();
         SetPerspectiveProjection(fieldOfView, aspectRatio, nearPlane, farPlane);
+        UpdateViewMatrix();
     }
-
-
 
     public void UpdateViewMatrix()
     {
-        Vector3 up = Vector3.UnitY;
-        View = Matrix4.LookAt(Position, LookingAt, up);
+        View = Matrix4.LookAt(Position, Position + front, up);
     }
-
-
 
     public void SetPerspectiveProjection(float fieldOfView, float aspectRatio, float nearPlane, float farPlane)
     {
         Projection = Matrix4.CreatePerspectiveFieldOfView(fieldOfView, aspectRatio, nearPlane, farPlane);
-
     }
 
-
+    void UpdateCameraVectors()
+    {
+        Vector3 f;
+        f.X = MathF.Cos(MathHelper.DegreesToRadians(Yaw)) * MathF.Cos(MathHelper.DegreesToRadians(Pitch));
+        f.Y = MathF.Sin(MathHelper.DegreesToRadians(Pitch));
+        f.Z = MathF.Sin(MathHelper.DegreesToRadians(Yaw)) * MathF.Cos(MathHelper.DegreesToRadians(Pitch));
+        front = Vector3.Normalize(f);
+        right = Vector3.Normalize(Vector3.Cross(front, Vector3.UnitY));
+        up = Vector3.Normalize(Vector3.Cross(right, front));
+    }
 
     public void ProcessKeyboard(KeyboardState input, float deltaTime)
     {
-        float moveSpeed = 5f * deltaTime;
-
+        float velocity = MovementSpeed * deltaTime;
         if (input.IsKeyDown(Keys.LeftShift) || input.IsKeyDown(Keys.RightShift))
-        {
-            moveSpeed *= 5.0f;
-        }
+            velocity *= 5f;
 
-        Vector3 forward = LookingAt - Position;
+        if (input.IsKeyDown(Keys.W))
+            Position += front * velocity;
+        if (input.IsKeyDown(Keys.S))
+            Position -= front * velocity;
+        if (input.IsKeyDown(Keys.A))
+            Position -= right * velocity;
+        if (input.IsKeyDown(Keys.D))
+            Position += right * velocity;
+        if (input.IsKeyDown(Keys.Space))
+            Position += up * velocity;
+        if (input.IsKeyDown(Keys.LeftControl) || input.IsKeyDown(Keys.RightControl))
+            Position -= up * velocity;
 
-        if (forward.Length > 0)
-        {
-            forward = Vector3.Normalize(forward);
+        UpdateViewMatrix();
+    }
 
-            Vector3 right = Vector3.Normalize(Vector3.Cross(forward, Up));
+    public void ProcessMouseMovement(float deltaX, float deltaY)
+    {
+        deltaX *= MouseSensitivity;
+        deltaY *= MouseSensitivity;
 
-            if (input.IsKeyDown(Keys.W))
-            {
-                Position += moveSpeed * forward;
-            }
-            if (input.IsKeyDown(Keys.S))
-            {
-                Position -= moveSpeed * forward;
-            }
-            if (input.IsKeyDown(Keys.A))
-            {
-                Position -= moveSpeed * right;
-            }
-            if (input.IsKeyDown(Keys.D))
-            {
-                Position += moveSpeed * right;
-            }
-            if (input.IsKeyDown(Keys.Space))
-            {
-                Position += moveSpeed * Up;
-            }
-            if (input.IsKeyDown(Keys.LeftControl) || input.IsKeyDown(Keys.RightControl))
-            {
-                Position -= moveSpeed * Up;
-            }
+        Yaw += deltaX;
+        Pitch += InvertY ? deltaY : -deltaY;
+        Pitch = MathHelper.Clamp(Pitch, -89f, 89f);
 
-            UpdateViewMatrix();
-        }
+        UpdateCameraVectors();
+        UpdateViewMatrix();
+    }
+
+    public void ProcessMouseScroll(float offset)
+    {
+        MovementSpeed = MathF.Max(0.1f, MovementSpeed + offset);
     }
 }
+

--- a/src/UI/UI.cs
+++ b/src/UI/UI.cs
@@ -14,7 +14,7 @@ namespace RenderMaster;
 
 public interface IUserInterface
 {
-    public void Update(FrameEventArgs args, Camera camera);
+    public void Update(FrameEventArgs args, Camera camera, bool mouseGrabbed);
 
     public void Render();
 
@@ -111,7 +111,7 @@ public class UI : IUserInterface
     }
 
     [MeasureExecutionTime]
-    public void Update(FrameEventArgs args, Camera camera)
+    public void Update(FrameEventArgs args, Camera camera, bool mouseGrabbed)
     {
         ImGui.SetCurrentContext(context);
         ImGuiIOPtr io = ImGui.GetIO();
@@ -121,10 +121,10 @@ public class UI : IUserInterface
         double frameRate = 1.0 / args.Time;
         string fpsString = frameRate.ToString("F2");
 
+        ImGuiWindowFlags windowFlags = ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoBackground;
+
         ImGui.SetNextWindowPos(new System.Numerics.Vector2(io.DisplaySize.X - 100, 0));
         ImGui.SetNextWindowSize(new System.Numerics.Vector2(100, 20));
-
-        ImGuiWindowFlags windowFlags = ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoMove | ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoBackground;
         if (ImGui.Begin("FPS Counter", windowFlags))
         {
             ImGui.PushStyleColor(ImGuiCol.Text, new System.Numerics.Vector4(1.0f, 1.0f, 1.0f, 1.0f));
@@ -132,6 +132,17 @@ public class UI : IUserInterface
             ImGui.PopStyleColor();
         }
         ImGui.End();
+
+        if (mouseGrabbed)
+        {
+            ImGui.SetNextWindowPos(new System.Numerics.Vector2(io.DisplaySize.X - 150, 20));
+            ImGui.SetNextWindowSize(new System.Numerics.Vector2(150, 20));
+            if (ImGui.Begin("MouseGrabState", windowFlags))
+            {
+                ImGui.Text("(mouseGrabbed)");
+            }
+            ImGui.End();
+        }
 
         if (ImGui.Begin("Debug Window"))
         {


### PR DESCRIPTION
## Summary
- move keyboard and mouse event handling into a dedicated `Input` class
- add mouse-grab toggle with `Z` including cursor locking and speed scroll
- implement mouselook WASD fly camera with optional inverted Y look
- display `(mouseGrabbed)` indicator in UI when cursor is locked

## Testing
- `dotnet build RenderMaster.csproj` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b34b054c4c8326a413cb55ef54a138