### PR TITLE
Enable UI scissoring

### DIFF
--- a/src/Graphics/State/OpenGLState.cs
+++ b/src/Graphics/State/OpenGLState.cs
@@ -10,8 +10,10 @@ public class OpenGLStateSnapshot
 
 public bool DepthTestEnabled { get; private set; }
 public bool CullFaceEnabled { get; private set; }
+public bool ScissorTestEnabled { get; private set; }
 public PolygonMode PolygonMode { get; private set; }
 public Rectangle Viewport { get; private set; }
+public Rectangle ScissorBox { get; private set; }
 public DepthFunction DepthFunc { get; private set; }
 public BlendingFactorSrc BlendSrc { get; private set; }
 public BlendingFactorDest BlendDest { get; private set; }
@@ -27,6 +29,8 @@ public OpenGLStateSnapshot()
 
     CullFaceEnabled = GL.IsEnabled(EnableCap.CullFace);
 
+    ScissorTestEnabled = GL.IsEnabled(EnableCap.ScissorTest);
+
 
     GL.GetInteger(GetPName.PolygonMode, out int polygonMode);
     PolygonMode = (PolygonMode)polygonMode;
@@ -35,6 +39,10 @@ public OpenGLStateSnapshot()
     int[] viewport = new int[4];
     GL.GetInteger(GetPName.Viewport, viewport);
     Viewport = new Rectangle(viewport[0], viewport[1], viewport[2], viewport[3]);
+
+    int[] scissorBox = new int[4];
+    GL.GetInteger(GetPName.ScissorBox, scissorBox);
+    ScissorBox = new Rectangle(scissorBox[0], scissorBox[1], scissorBox[2], scissorBox[3]);
 
 
     GL.GetInteger(GetPName.DepthFunc, out int depthFunc);
@@ -71,11 +79,18 @@ public void Restore()
     else
         GL.Disable(EnableCap.CullFace);
 
+    if (ScissorTestEnabled)
+        GL.Enable(EnableCap.ScissorTest);
+    else
+        GL.Disable(EnableCap.ScissorTest);
+
 
     GL.PolygonMode(MaterialFace.FrontAndBack, PolygonMode);
 
 
     GL.Viewport(Viewport.Left, Viewport.Top, Viewport.Width, Viewport.Height);
+
+    GL.Scissor(ScissorBox.Left, ScissorBox.Top, ScissorBox.Width, ScissorBox.Height);
 
 
     GL.DepthFunc(DepthFunc);

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -205,16 +205,15 @@ public class Game : GameWindow
 
         userInterface?.Resize(e);
 
-
         var io = ImGui.GetIO();
         io.DisplaySize = new System.Numerics.Vector2(e.Width, e.Height);
 
-
-        var framebufferWidth = (int)(e.Width * io.DisplayFramebufferScale.X);
-        var framebufferHeight = (int)(e.Height * io.DisplayFramebufferScale.Y);
-
-
-        GL.Viewport(0, 0, framebufferWidth, framebufferHeight);
+        unsafe
+        {
+            GLFW.GetFramebufferSize(WindowPtr, out int fbWidth, out int fbHeight);
+            io.DisplayFramebufferScale = new System.Numerics.Vector2((float)fbWidth / e.Width, (float)fbHeight / e.Height);
+            GL.Viewport(0, 0, fbWidth, fbHeight);
+        }
     }
 
 }

--- a/src/UI/UI.cs
+++ b/src/UI/UI.cs
@@ -50,7 +50,6 @@ public class UI : IUserInterface
         GL.BlendFunc(BlendingFactor.SrcAlpha, BlendingFactor.OneMinusSrcAlpha);
         GL.Disable(EnableCap.CullFace);
         GL.Disable(EnableCap.DepthTest);
-        GL.Disable(EnableCap.ScissorTest);
     }
 
     public void Resize(ResizeEventArgs e)
@@ -197,6 +196,11 @@ public class UI : IUserInterface
                     GL.BindTexture(TextureTarget.Texture2D, (int)pcmd.TextureId);
 
                     var clip = pcmd.ClipRect;
+                    GL.Scissor(
+                        (int)clip.X,
+                        (int)(io.DisplaySize.Y - clip.W),
+                        (int)(clip.Z - clip.X),
+                        (int)(clip.W - clip.Y));
 
                     if ((io.BackendFlags & ImGuiBackendFlags.RendererHasVtxOffset) != 0)
                     {


### PR DESCRIPTION
## Summary
- keep scissor test active while UI renders and apply per-draw clip rects
- restore scissor state in OpenGL snapshot stack
- update resize handling to set DisplayFramebufferScale

## Testing
- `dotnet build RenderMaster.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b3558476448326bcb94f744f7c4483