### PR TITLE
Add CPU texture and material storage

### DIFF
--- a/src/NewGraphics/Ideas.cs
+++ b/src/NewGraphics/Ideas.cs
@@ -3,9 +3,11 @@ using OpenTK.Windowing.Common.Input;
 using SharpGLTF.Memory;
 using SharpGLTF.Schema2;
 using SharpGLTF.Validation;
+using StbImageSharp;
 using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Numerics;
 using System.Reflection;
@@ -16,8 +18,8 @@ using System.Threading.Tasks;
 namespace RenderMaster.src.NewGraphics
 {
     using MeshHandle = Handle<PreparedMeshBuffer>;
-    using TextureHandle = Handle<TextureGPU>;
-    using MaterialHandle = Handle<MaterialGPU>;
+    using TextureHandle = Handle<PreparedTexture>;
+    using MaterialHandle = Handle<MaterialCPU>;
 
 
     readonly record struct Handle<T>(int Id);
@@ -25,11 +27,25 @@ namespace RenderMaster.src.NewGraphics
     class CPUResourceTable
     {
         List<PreparedMeshBuffer> meshBuffers = new List<PreparedMeshBuffer>();
+        List<PreparedTexture> textures = new List<PreparedTexture>();
+        List<MaterialCPU> materials = new List<MaterialCPU>();
 
         public MeshHandle AddMeshBuffer(PreparedMeshBuffer buffer)
         {
             meshBuffers.Add(buffer);
             return new MeshHandle(meshBuffers.Count - 1);
+        }
+
+        public TextureHandle AddTexture(PreparedTexture tex)
+        {
+            textures.Add(tex);
+            return new TextureHandle(textures.Count - 1);
+        }
+
+        public MaterialHandle AddMaterial(MaterialCPU mat)
+        {
+            materials.Add(mat);
+            return new MaterialHandle(materials.Count - 1);
         }
     }
 
@@ -63,22 +79,65 @@ namespace RenderMaster.src.NewGraphics
         public void LoadResources(CPUResourceTable table)
         {
             var model = ModelRoot.Load(filepath);
-            //create node graph
+
+            var texMap = new Dictionary<SharpGLTF.Schema2.Texture, TextureHandle>();
+            foreach (var tex in model.LogicalTextures)
+            {
+                var bytes = tex.PrimaryImage?.Content?.Content.ToArray() ?? Array.Empty<byte>();
+                var prepared = new PreparedTexture(bytes);
+                var handle = table.AddTexture(prepared);
+                texMap[tex] = handle;
+            }
+
+            var matMap = new Dictionary<SharpGLTF.Schema2.Material, MaterialHandle>();
+            foreach (var mat in model.LogicalMaterials)
+            {
+                var material = new MaterialCPU();
+                var baseColor = mat.FindChannel("BaseColor")?.Texture;
+                if (baseColor != null && texMap.TryGetValue(baseColor, out var th))
+                    material.Textures["BaseColor"] = th;
+                var mHandle = table.AddMaterial(material);
+                matMap[mat] = mHandle;
+            }
 
             foreach (var mesh in model.LogicalMeshes)
             {
-                // convert to prepared mesh buffer
                 var prepared = new PreparedMeshBuffer(mesh);
-                var handle = table.AddMeshBuffer(prepared);
+                var meshHandle = table.AddMeshBuffer(prepared);
 
-                // create scene node if it doesn't exist with references to loaded materials
+                var prim = mesh.Primitives.FirstOrDefault();
+                var matHandle = prim != null && prim.Material != null && matMap.TryGetValue(prim.Material, out var mh)
+                    ? mh
+                    : new MaterialHandle(0);
+
                 var node = new SceneNode
                 {
-                    mesh = handle,
-                    material = new MaterialHandle(0) // placeholder
+                    mesh = meshHandle,
+                    material = matHandle
                 };
             }
         }
+    }
+
+    class PreparedTexture
+    {
+        public int Width { get; }
+        public int Height { get; }
+        public byte[] Pixels { get; } = Array.Empty<byte>();
+
+        public PreparedTexture(byte[] bytes)
+        {
+            using var ms = new MemoryStream(bytes);
+            var img = ImageResult.FromStream(ms, ColorComponents.RedGreenBlueAlpha);
+            Width = img.Width;
+            Height = img.Height;
+            Pixels = img.Data;
+        }
+    }
+
+    class MaterialCPU
+    {
+        public Dictionary<string, TextureHandle> Textures { get; } = new();
     }
 
     // A contiguous index range you can draw with one material (one glTF primitive)


### PR DESCRIPTION
## Summary
- extend CPU resource table with texture and material lists
- decode glTF images into PreparedTexture and map materials to textures

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3acfce1348326bc2144b33c7a8199