### PR TITLE
Load PBR material properties from glTF

### DIFF
--- a/src/NewGraphics/Loading/LoadFromGltfFile.cs
+++ b/src/NewGraphics/Loading/LoadFromGltfFile.cs
@@ -34,9 +34,29 @@ namespace RenderMaster.src.NewGraphics.Loading
             foreach (var mat in model.LogicalMaterials)
             {
                 var material = new MaterialCPU();
-                var baseColor = mat.FindChannel("BaseColor")?.Texture;
-                if (baseColor != null && texMap.TryGetValue(baseColor, out var th))
-                    material.Textures["BaseColor"] = th;
+
+                material.DoubleSided = mat.DoubleSided;
+
+                var pbr = mat.PbrMetallicRoughness;
+                if (pbr != null)
+                {
+                    material.BaseColorFactor = pbr.BaseColorFactor;
+                    material.MetallicFactor = pbr.MetallicFactor;
+                    material.RoughnessFactor = pbr.RoughnessFactor;
+
+                    var bc = pbr.BaseColorTexture?.Texture;
+                    if (bc != null && texMap.TryGetValue(bc, out var bcHandle))
+                        material.Textures["BaseColorTexture"] = bcHandle;
+
+                    var mr = pbr.MetallicRoughnessTexture?.Texture;
+                    if (mr != null && texMap.TryGetValue(mr, out var mrHandle))
+                        material.Textures["MetallicRoughnessTexture"] = mrHandle;
+                }
+
+                var normal = mat.FindChannel("Normal")?.Texture;
+                if (normal != null && texMap.TryGetValue(normal, out var nHandle))
+                    material.Textures["NormalTexture"] = nHandle;
+
                 var mHandle = table.AddMaterial(material);
                 matMap[mat] = mHandle;
             }

--- a/src/NewGraphics/Resources/MaterialCPU.cs
+++ b/src/NewGraphics/Resources/MaterialCPU.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Numerics;
 using RenderMaster.src.NewGraphics.Types;
 
 namespace RenderMaster.src.NewGraphics.Resources
@@ -8,6 +9,13 @@ namespace RenderMaster.src.NewGraphics.Resources
     class MaterialCPU
     {
         public Dictionary<string, TextureHandle> Textures { get; } = new();
+
+        // PBR material factors. Null indicates the value was not specified
+        // in the source glTF and defaults should be used.
+        public Vector4? BaseColorFactor { get; set; }
+        public float? MetallicFactor { get; set; }
+        public float? RoughnessFactor { get; set; }
+        public bool? DoubleSided { get; set; }
     }
 }
 


### PR DESCRIPTION
## Summary
- capture glTF PBR factors (base color, metallic, roughness, etc.) in CPU-side materials
- map glTF textures to named material slots when loading models

## Testing
- `dotnet build RenderMaster.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b60242fc8326a36dd71c095b3db8