### PR TITLE
Implement resource uploader with stable handle mapping

### DIFF
--- a/src/NewGraphics/Resources/CPUResourceTable.cs
+++ b/src/NewGraphics/Resources/CPUResourceTable.cs
@@ -13,6 +13,10 @@ namespace RenderMaster.src.NewGraphics.Resources
         List<PreparedTexture> textures = new List<PreparedTexture>();
         List<MaterialCPU> materials = new List<MaterialCPU>();
 
+        public IReadOnlyList<PreparedMeshBuffer> MeshBuffers => meshBuffers;
+        public IReadOnlyList<PreparedTexture> Textures => textures;
+        public IReadOnlyList<MaterialCPU> Materials => materials;
+
         public MeshHandle AddMeshBuffer(PreparedMeshBuffer buffer)
         {
             meshBuffers.Add(buffer);

--- a/src/NewGraphics/Resources/GPUResourceTable.cs
+++ b/src/NewGraphics/Resources/GPUResourceTable.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using OpenTK.Graphics.OpenGL4;
 using RenderMaster.src.NewGraphics.Types;
 
@@ -36,9 +37,9 @@ namespace RenderMaster.src.NewGraphics.Resources
         readonly List<TextureGPU> textures = new();
         readonly List<MaterialGPU> materials = new();
 
-        public ref readonly MeshGPU GetMesh(MeshHandle h) => ref meshes[h.Id];
-        public ref readonly TextureGPU GetTexture(TextureHandle h) => ref textures[h.Id];
-        public ref readonly MaterialGPU GetMaterial(MaterialHandle h) => ref materials[h.Id];
+        public ref readonly MeshGPU GetMesh(MeshHandle h) => ref CollectionsMarshal.AsSpan(meshes)[h.Id];
+        public ref readonly TextureGPU GetTexture(TextureHandle h) => ref CollectionsMarshal.AsSpan(textures)[h.Id];
+        public ref readonly MaterialGPU GetMaterial(MaterialHandle h) => ref CollectionsMarshal.AsSpan(materials)[h.Id];
 
         public MeshHandle CreateMesh(PreparedMeshBuffer cpu)
         {

--- a/src/NewGraphics/Resources/GPUResourceTable.cs
+++ b/src/NewGraphics/Resources/GPUResourceTable.cs
@@ -36,6 +36,10 @@ namespace RenderMaster.src.NewGraphics.Resources
         readonly List<TextureGPU> textures = new();
         readonly List<MaterialGPU> materials = new();
 
+        public ref readonly MeshGPU GetMesh(MeshHandle h) => ref meshes[h.Id];
+        public ref readonly TextureGPU GetTexture(TextureHandle h) => ref textures[h.Id];
+        public ref readonly MaterialGPU GetMaterial(MaterialHandle h) => ref materials[h.Id];
+
         public MeshHandle CreateMesh(PreparedMeshBuffer cpu)
         {
             GL.CreateVertexArrays(1, out int vao);
@@ -109,20 +113,33 @@ namespace RenderMaster.src.NewGraphics.Resources
             return new TextureHandle(textures.Count - 1);
         }
 
-        public MaterialHandle CreateMaterial(MaterialCPU cpu)
+        public MaterialHandle CreateMaterialResolved(Dictionary<string, (int textureId, int samplerId)> texDict)
         {
-            var mat = new MaterialGPU { textures = new Dictionary<string, (int, int)>() };
-            foreach (var kv in cpu.Textures)
-            {
-                var handle = kv.Value.Id;
-                if (handle >= 0 && handle < textures.Count)
-                {
-                    var tex = textures[handle];
-                    mat.textures[kv.Key] = (tex.id, tex.sampler);
-                }
-            }
+            var mat = new MaterialGPU { textures = texDict };
             materials.Add(mat);
             return new MaterialHandle(materials.Count - 1);
+        }
+
+        public void Destroy(MeshHandle h)
+        {
+            var mesh = meshes[h.Id];
+            if (mesh.ebo != 0) GL.DeleteBuffer(mesh.ebo);
+            GL.DeleteBuffer(mesh.vbo);
+            GL.DeleteVertexArray(mesh.vao);
+            meshes[h.Id] = default;
+        }
+
+        public void Destroy(TextureHandle h)
+        {
+            var tex = textures[h.Id];
+            GL.DeleteTexture(tex.id);
+            GL.DeleteSampler(tex.sampler);
+            textures[h.Id] = default;
+        }
+
+        public void Destroy(MaterialHandle h)
+        {
+            materials[h.Id] = default;
         }
     }
 }

--- a/src/NewGraphics/Resources/ResourceUploader.cs
+++ b/src/NewGraphics/Resources/ResourceUploader.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using RenderMaster.src.NewGraphics.Types;
+
+namespace RenderMaster.src.NewGraphics.Resources
+{
+    sealed class ResourceUploader
+    {
+        private int uploadedTexCount  = 0;
+        private int uploadedMeshCount = 0;
+        private int uploadedMatCount  = 0;
+
+        private int[] texRemap  = Array.Empty<int>();
+        private int[] meshRemap = Array.Empty<int>();
+        private int[] matRemap  = Array.Empty<int>();
+
+        private readonly SamplerDesc defaultSampler;
+
+        public ResourceUploader(SamplerDesc defaultSampler) => this.defaultSampler = defaultSampler;
+
+        public UploadResult UploadIncremental(CPUResourceTable cpu, GPUResourceTable gpu)
+        {
+            EnsureSize(ref texRemap,  cpu.Textures.Count);
+            EnsureSize(ref meshRemap, cpu.MeshBuffers.Count);
+            EnsureSize(ref matRemap,  cpu.Materials.Count);
+
+            for (int i = uploadedTexCount; i < cpu.Textures.Count; i++)
+            {
+                var cpuTex = cpu.Textures[i];
+                var gpuTex = gpu.CreateTexture(cpuTex, defaultSampler);
+                texRemap[i] = gpuTex.Id;
+            }
+            uploadedTexCount = cpu.Textures.Count;
+
+            for (int i = uploadedMeshCount; i < cpu.MeshBuffers.Count; i++)
+            {
+                var cpuMesh = cpu.MeshBuffers[i];
+                var gpuMesh = gpu.CreateMesh(cpuMesh);
+                meshRemap[i] = gpuMesh.Id;
+            }
+            uploadedMeshCount = cpu.MeshBuffers.Count;
+
+            for (int i = uploadedMatCount; i < cpu.Materials.Count; i++)
+            {
+                var cpuMat = cpu.Materials[i];
+
+                var texDict = new Dictionary<string, (int textureId, int samplerId)>();
+                foreach (var (semantic, cpuTexHandle) in cpuMat.Textures)
+                {
+                    var gpuTexHandle = RemapTexture(cpuTexHandle);
+                    if (!gpuTexHandle.IsValid)
+                    {
+                        continue;
+                    }
+                    var tex = gpu.GetTexture(gpuTexHandle);
+                    texDict[semantic] = (tex.id, tex.sampler);
+                }
+
+                var gpuMat = gpu.CreateMaterialResolved(texDict);
+                matRemap[i] = gpuMat.Id;
+            }
+            uploadedMatCount = cpu.Materials.Count;
+
+            return new UploadResult
+            {
+                CpuToGpu_Tex  = (int[])texRemap.Clone(),
+                CpuToGpu_Mesh = (int[])meshRemap.Clone(),
+                CpuToGpu_Mat  = (int[])matRemap.Clone()
+            };
+
+            Handle<GPUResourceTable.TextureGPU> RemapTexture(Handle<PreparedTexture> h) =>
+                h.IsValid && h.Id < texRemap.Length && texRemap[h.Id] >= 0
+                    ? new Handle<GPUResourceTable.TextureGPU>(texRemap[h.Id])
+                    : Handle<GPUResourceTable.TextureGPU>.Invalid;
+        }
+
+        private static void EnsureSize(ref int[] arr, int size)
+        {
+            if (arr.Length >= size) return;
+            var old = arr;
+            arr = new int[size];
+            Array.Fill(arr, -1);
+            Array.Copy(old, arr, old.Length);
+        }
+    }
+}

--- a/src/NewGraphics/Resources/UploadResult.cs
+++ b/src/NewGraphics/Resources/UploadResult.cs
@@ -1,0 +1,34 @@
+using System;
+using RenderMaster.src.NewGraphics.Types;
+
+namespace RenderMaster.src.NewGraphics.Resources
+{
+    using MeshGPUHandle = Handle<GPUResourceTable.MeshGPU>;
+    using TextureGPUHandle = Handle<GPUResourceTable.TextureGPU>;
+    using MaterialGPUHandle = Handle<GPUResourceTable.MaterialGPU>;
+    using CpuMeshHandle = Handle<PreparedMeshBuffer>;
+    using CpuTexHandle = Handle<PreparedTexture>;
+    using CpuMatHandle = Handle<MaterialCPU>;
+
+    sealed class UploadResult
+    {
+        public int[] CpuToGpu_Mesh  = Array.Empty<int>();
+        public int[] CpuToGpu_Tex   = Array.Empty<int>();
+        public int[] CpuToGpu_Mat   = Array.Empty<int>();
+
+        public MeshGPUHandle Map(CpuMeshHandle h) =>
+            h.IsValid && h.Id < CpuToGpu_Mesh.Length && CpuToGpu_Mesh[h.Id] >= 0
+                ? new MeshGPUHandle(CpuToGpu_Mesh[h.Id])
+                : MeshGPUHandle.Invalid;
+
+        public TextureGPUHandle Map(CpuTexHandle h) =>
+            h.IsValid && h.Id < CpuToGpu_Tex.Length && CpuToGpu_Tex[h.Id] >= 0
+                ? new TextureGPUHandle(CpuToGpu_Tex[h.Id])
+                : TextureGPUHandle.Invalid;
+
+        public MaterialGPUHandle Map(CpuMatHandle h) =>
+            h.IsValid && h.Id < CpuToGpu_Mat.Length && CpuToGpu_Mat[h.Id] >= 0
+                ? new MaterialGPUHandle(CpuToGpu_Mat[h.Id])
+                : MaterialGPUHandle.Invalid;
+    }
+}

--- a/src/NewGraphics/Types/Handle.cs
+++ b/src/NewGraphics/Types/Handle.cs
@@ -1,5 +1,10 @@
 namespace RenderMaster.src.NewGraphics.Types
 {
-    readonly record struct Handle<T>(int Id);
+    readonly record struct Handle<T>(int Id)
+    {
+        public bool IsValid => Id >= 0;
+        public static Handle<T> Invalid => new(-1);
+        public override string ToString() => IsValid ? $"{typeof(T).Name}#{Id}" : $"{typeof(T).Name}<Invalid>";
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `Handle<T>` with validity checks and invalid sentinel
- expose CPUResourceTable contents for iteration
- expand GPUResourceTable with accessors, destroy methods, and resolved material creation
- introduce UploadResult and ResourceUploader for incremental CPU→GPU resource transfers

## Testing
- `dotnet build RenderMaster.csproj` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c7291fd08326a08f3366342e9613