### PR TITLE
Add uniform block bindings and UBO helpers

### DIFF
--- a/EngineBaseDir/Shaders/common_blocks.glsl
+++ b/EngineBaseDir/Shaders/common_blocks.glsl
@@ -1,0 +1,15 @@
+#version 450 core
+layout(std140, binding = 0) uniform FrameBlock {
+    mat4 uViewProj;
+    vec3 uCameraWS; float uTime;
+};
+
+layout(std140, binding = 1) uniform ObjectBlock {
+    mat4 uWorld;
+    mat4 uNormalWorld;
+};
+
+layout(std140, binding = 2) uniform MaterialBlock {
+    vec4  uBaseColorFactor;
+    float uMetallic; float uRoughness; float uAlphaCutoff; float uFlags;
+};

--- a/src/NewGraphics/Programs/BindingPoints.cs
+++ b/src/NewGraphics/Programs/BindingPoints.cs
@@ -1,0 +1,17 @@
+namespace RenderMaster.src.NewGraphics.Programs
+{
+    static class BindingPoints
+    {
+        public const int Frame = 0;
+        public const int Object = 1;
+        public const int Material = 2;
+        public const int Lights = 3;
+    }
+
+    static class TextureUnits
+    {
+        public const int BaseColor = 0;
+        public const int Normal = 1;
+        public const int MetallicRoughness = 2;
+    }
+}

--- a/src/NewGraphics/Programs/ProgramUniforms.cs
+++ b/src/NewGraphics/Programs/ProgramUniforms.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace RenderMaster.src.NewGraphics.Programs
+{
+    sealed class ProgramUniforms : IDisposable
+    {
+        public readonly UboRing<ObjectBlock> ObjectRing;
+        public readonly UniformBuffer<FrameBlock> Frame;
+
+        public ProgramUniforms(int objectPerFrame = 65_536)
+        {
+            ObjectRing = new UboRing<ObjectBlock>(objectPerFrame);
+            Frame = new UniformBuffer<FrameBlock>();
+        }
+
+        public void BeginFrame() => ObjectRing.BeginFrame();
+
+        public void Dispose()
+        {
+            ObjectRing.Dispose();
+            Frame.Dispose();
+        }
+    }
+}

--- a/src/NewGraphics/Programs/UboRing.cs
+++ b/src/NewGraphics/Programs/UboRing.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Runtime.InteropServices;
+using OpenTK.Graphics.OpenGL4;
+
+namespace RenderMaster.src.NewGraphics.Programs
+{
+    sealed class UboRing<T> : IDisposable where T : struct
+    {
+        readonly int _buffer;
+        readonly int _size;
+        readonly int _stride;
+        readonly int _frames;
+        readonly int _perFrameCount;
+        readonly IntPtr _ptr;
+        int _frameIndex;
+        int _cursor;
+
+        public UboRing(int perFrameCount, int frames = 3)
+        {
+            _stride = ((Marshal.SizeOf<T>() + 255) / 256) * 256;
+            _perFrameCount = perFrameCount;
+            _frames = frames;
+            _size = _stride * perFrameCount * frames;
+
+            GL.CreateBuffers(1, out _buffer);
+            GL.NamedBufferStorage(_buffer, _size, IntPtr.Zero,
+                BufferStorageFlags.MapPersistentBit | BufferStorageFlags.MapWriteBit | BufferStorageFlags.DynamicStorageBit);
+            _ptr = GL.MapNamedBufferRange(_buffer, IntPtr.Zero, _size,
+                BufferAccessMask.MapWriteBit | BufferAccessMask.MapPersistentBit | BufferAccessMask.MapInvalidateRangeBit);
+        }
+
+        public void BeginFrame()
+        {
+            _frameIndex = (_frameIndex + 1) % _frames;
+            _cursor = 0;
+        }
+
+        public (int buffer, int offset) Push(in T data)
+        {
+            if (_cursor >= _perFrameCount)
+                throw new InvalidOperationException("UboRing exhausted for frame");
+            int offset = (_frameIndex * _perFrameCount + _cursor) * _stride;
+            unsafe
+            {
+                System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(
+                    (void*)((nint)_ptr + offset),
+                    System.Runtime.CompilerServices.Unsafe.AsPointer(ref System.Runtime.CompilerServices.Unsafe.AsRef(data)),
+                    (uint)Marshal.SizeOf<T>());
+            }
+            _cursor++;
+            return (_buffer, offset);
+        }
+
+        public void BindRange(int bindingPoint, int offset) =>
+            GL.BindBufferRange(BufferRangeTarget.UniformBuffer, bindingPoint, _buffer, (IntPtr)offset, _stride);
+
+        public void Dispose()
+        {
+            GL.UnmapNamedBuffer(_buffer);
+            GL.DeleteBuffer(_buffer);
+        }
+    }
+}

--- a/src/NewGraphics/Programs/UniformBlocks.cs
+++ b/src/NewGraphics/Programs/UniformBlocks.cs
@@ -1,0 +1,29 @@
+using System.Numerics;
+using System.Runtime.InteropServices;
+
+namespace RenderMaster.src.NewGraphics.Programs
+{
+    [StructLayout(LayoutKind.Sequential, Pack = 16)]
+    struct FrameBlock
+    {
+        public Matrix4x4 ViewProj;
+        public Vector3 CameraWS; public float Time;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 16)]
+    struct ObjectBlock
+    {
+        public Matrix4x4 World;
+        public Matrix4x4 NormalWorld;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 16)]
+    struct MaterialBlock
+    {
+        public Vector4 BaseColorFactor;
+        public float Metallic;
+        public float Roughness;
+        public float AlphaCutoff;
+        public float Flags;
+    }
+}

--- a/src/NewGraphics/Programs/UniformBuffer.cs
+++ b/src/NewGraphics/Programs/UniformBuffer.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Runtime.InteropServices;
+using OpenTK.Graphics.OpenGL4;
+
+namespace RenderMaster.src.NewGraphics.Programs
+{
+    sealed class UniformBuffer<T> : IDisposable where T : struct
+    {
+        readonly int _buffer;
+        readonly int _size;
+        readonly IntPtr _ptr;
+
+        public UniformBuffer()
+        {
+            _size = Marshal.SizeOf<T>();
+            GL.CreateBuffers(1, out _buffer);
+            GL.NamedBufferStorage(_buffer, _size, IntPtr.Zero,
+                BufferStorageFlags.MapWriteBit | BufferStorageFlags.MapPersistentBit | BufferStorageFlags.DynamicStorageBit);
+            _ptr = GL.MapNamedBufferRange(_buffer, IntPtr.Zero, _size,
+                BufferAccessMask.MapWriteBit | BufferAccessMask.MapPersistentBit | BufferAccessMask.MapInvalidateBufferBit);
+        }
+
+        public void Update(in T data)
+        {
+            unsafe
+            {
+                System.Runtime.CompilerServices.Unsafe.CopyBlockUnaligned(
+                    (void*)_ptr,
+                    System.Runtime.CompilerServices.Unsafe.AsPointer(ref System.Runtime.CompilerServices.Unsafe.AsRef(data)),
+                    (uint)_size);
+            }
+        }
+
+        public void Bind(int bindingPoint) =>
+            GL.BindBufferBase(BufferRangeTarget.UniformBuffer, bindingPoint, _buffer);
+
+        public void Dispose()
+        {
+            GL.UnmapNamedBuffer(_buffer);
+            GL.DeleteBuffer(_buffer);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add BindingPoints and TextureUnits constants
- mirror GLSL uniform blocks in C# structs and common_blocks.glsl
- implement UboRing, UniformBuffer, and ProgramUniforms with Frame/Object blocks

## Testing
- `dotnet build RenderMaster.csproj` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b3e1f8b1448326a5462386f92e72ca