### PR TITLE
Ensure coherent uniform buffers and correct view-projection

### DIFF
--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -87,7 +87,9 @@ public class Game : GameWindow
 
         var view = ToNum(camera.View);
         var proj = ToNum(camera.Projection);
-        var viewProj = System.Numerics.Matrix4x4.Transpose(view * proj);
+
+        // For column-major GLSL matrices, multiply projection * view and transpose
+        var viewProj = System.Numerics.Matrix4x4.Transpose(proj * view);
 
         var frame = new FrameBlock
         {

--- a/src/NewGraphics/Programs/UboRing.cs
+++ b/src/NewGraphics/Programs/UboRing.cs
@@ -24,9 +24,9 @@ namespace RenderMaster.src.NewGraphics.Programs
 
             GL.CreateBuffers(1, out _buffer);
             GL.NamedBufferStorage(_buffer, _size, IntPtr.Zero,
-                BufferStorageFlags.MapPersistentBit | BufferStorageFlags.MapWriteBit | BufferStorageFlags.DynamicStorageBit);
+                BufferStorageFlags.MapPersistentBit | BufferStorageFlags.MapWriteBit | BufferStorageFlags.MapCoherentBit);
             _ptr = GL.MapNamedBufferRange(_buffer, IntPtr.Zero, _size,
-                BufferAccessMask.MapWriteBit | BufferAccessMask.MapPersistentBit | BufferAccessMask.MapInvalidateRangeBit);
+                BufferAccessMask.MapWriteBit | BufferAccessMask.MapPersistentBit | BufferAccessMask.MapCoherentBit);
         }
 
         public void BeginFrame()

--- a/src/NewGraphics/Programs/UniformBuffer.cs
+++ b/src/NewGraphics/Programs/UniformBuffer.cs
@@ -15,9 +15,9 @@ namespace RenderMaster.src.NewGraphics.Programs
             _size = Marshal.SizeOf<T>();
             GL.CreateBuffers(1, out _buffer);
             GL.NamedBufferStorage(_buffer, _size, IntPtr.Zero,
-                BufferStorageFlags.MapWriteBit | BufferStorageFlags.MapPersistentBit | BufferStorageFlags.DynamicStorageBit);
+                BufferStorageFlags.MapWriteBit | BufferStorageFlags.MapPersistentBit | BufferStorageFlags.MapCoherentBit);
             _ptr = GL.MapNamedBufferRange(_buffer, IntPtr.Zero, _size,
-                BufferAccessMask.MapWriteBit | BufferAccessMask.MapPersistentBit | BufferAccessMask.MapInvalidateBufferBit);
+                BufferAccessMask.MapWriteBit | BufferAccessMask.MapPersistentBit | BufferAccessMask.MapCoherentBit);
         }
 
         public void Update(in T data)


### PR DESCRIPTION
## Summary
- add MapCoherentBit to persistently-mapped uniform buffers
- fix view-projection multiplication order for column-major GLSL

## Testing
- `dotnet build` *(fails: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fb70c5148326ac7ff401be165d32