### PR TITLE
Fix GPU-to-CPU material mapping for materials

### DIFF
--- a/src/NewGraphics/Frame/RendererCore.cs
+++ b/src/NewGraphics/Frame/RendererCore.cs
@@ -42,11 +42,15 @@ namespace RenderMaster.src.NewGraphics.Frame
                 draws, gpu, programs, uniforms,
                 materialBlockOf: h =>
                 {
+                    int cpuId = (h.Id < map.GpuToCpu_Mat.Length && map.GpuToCpu_Mat[h.Id] >= 0)
+                        ? map.GpuToCpu_Mat[h.Id]
+                        : 0;
+                    ref var m = ref cpu.Materials[cpuId];
                     var mb = new MaterialBlock
                     {
-                        BaseColorFactor = cpu.Materials[map.CpuToGpu_Mat[h.Id] >= 0 ? h.Id : 0].BaseColorFactor ?? new Vector4(1,1,1,1),
-                        Metallic   = cpu.Materials[h.Id].MetallicFactor ?? 1f,
-                        Roughness  = cpu.Materials[h.Id].RoughnessFactor ?? 1f,
+                        BaseColorFactor = m.BaseColorFactor ?? new Vector4(1,1,1,1),
+                        Metallic   = m.MetallicFactor ?? 1f,
+                        Roughness  = m.RoughnessFactor ?? 1f,
                         AlphaCutoff = 0.5f,
                         Flags = 0f
                     };

--- a/src/NewGraphics/Resources/ResourceUploader.cs
+++ b/src/NewGraphics/Resources/ResourceUploader.cs
@@ -66,11 +66,21 @@ namespace RenderMaster.src.NewGraphics.Resources
                 $"UploadIncremental: cpu(tex={cpu.Textures.Count}, mesh={cpu.MeshBuffers.Count}, mat={cpu.Materials.Count}) → gpu(tex={uploadedTexCount}, mesh={uploadedMeshCount}, mat={uploadedMatCount})",
                 RenderMaster.Engine.LogLevel.Debug);
 
+            var gpuToCpuMat = new int[uploadedMatCount];
+            Array.Fill(gpuToCpuMat, -1);
+            for (int cpuId = 0; cpuId < uploadedMatCount; cpuId++)
+            {
+                var gpuId = matRemap[cpuId];
+                if (gpuId >= 0 && gpuId < gpuToCpuMat.Length)
+                    gpuToCpuMat[gpuId] = cpuId;
+            }
+
             return new UploadResult
             {
                 CpuToGpu_Tex  = (int[])texRemap.Clone(),
                 CpuToGpu_Mesh = (int[])meshRemap.Clone(),
-                CpuToGpu_Mat  = (int[])matRemap.Clone()
+                CpuToGpu_Mat  = (int[])matRemap.Clone(),
+                GpuToCpu_Mat  = gpuToCpuMat
             };
 
             Handle<GPUResourceTable.TextureGPU> RemapTexture(Handle<PreparedTexture> h) =>

--- a/src/NewGraphics/Resources/UploadResult.cs
+++ b/src/NewGraphics/Resources/UploadResult.cs
@@ -15,6 +15,7 @@ namespace RenderMaster.src.NewGraphics.Resources
         public int[] CpuToGpu_Mesh  = Array.Empty<int>();
         public int[] CpuToGpu_Tex   = Array.Empty<int>();
         public int[] CpuToGpu_Mat   = Array.Empty<int>();
+        public int[] GpuToCpu_Mat   = Array.Empty<int>();
 
         public MeshGPUHandle Map(CpuMeshHandle h) =>
             h.IsValid && h.Id < CpuToGpu_Mesh.Length && CpuToGpu_Mesh[h.Id] >= 0


### PR DESCRIPTION
## Summary
- add reverse GPU->CPU material map in upload results
- build MaterialBlock using reverse mapping

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b40d4bf5888326823c905cdcfcbc8a