### PR TITLE
Update camera aspect ratio when framebuffer resizes

### DIFF
--- a/src/Core/Camera.cs
+++ b/src/Core/Camera.cs
@@ -17,6 +17,11 @@ public class Camera
     public float MovementSpeed { get; private set; } = 5f;
     public float MouseSensitivity { get; private set; } = 0.2f;
 
+    public float FieldOfView { get; private set; }
+    public float NearPlane   { get; private set; }
+    public float FarPlane    { get; private set; }
+    public float AspectRatio { get; private set; }
+
     Vector3 front = -Vector3.UnitZ;
     Vector3 up = Vector3.UnitY;
     Vector3 right = Vector3.UnitX;
@@ -39,7 +44,22 @@ public class Camera
 
     public void SetPerspectiveProjection(float fieldOfView, float aspectRatio, float nearPlane, float farPlane)
     {
-        Projection = Matrix4.CreatePerspectiveFieldOfView(fieldOfView, aspectRatio, nearPlane, farPlane);
+        FieldOfView = fieldOfView;
+        AspectRatio = aspectRatio;
+        NearPlane   = nearPlane;
+        FarPlane    = farPlane;
+        UpdateProjection();
+    }
+
+    public void UpdateProjection()
+    {
+        Projection = Matrix4.CreatePerspectiveFieldOfView(FieldOfView, AspectRatio, NearPlane, FarPlane);
+    }
+
+    public void UpdateAspectRatio(float aspectRatio)
+    {
+        AspectRatio = aspectRatio;
+        UpdateProjection();
     }
 
     void UpdateCameraVectors()

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -157,6 +157,7 @@ public class Game : GameWindow
             GLFW.GetFramebufferSize(WindowPtr, out int fbWidth, out int fbHeight);
             io.DisplayFramebufferScale = new System.Numerics.Vector2((float)fbWidth / e.Width, (float)fbHeight / e.Height);
             GL.Viewport(0, 0, fbWidth, fbHeight);
+            camera.UpdateAspectRatio((float)fbWidth / fbHeight);
         }
 
         RenderMaster.Engine.Logger.Log(


### PR DESCRIPTION
## Summary
- store camera projection parameters for later recomputation
- refresh camera aspect ratio on framebuffer resize to avoid stretched output

## Testing
- `/root/.dotnet/dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68b49f18af408326a38819e6f241b0e6