### PR TITLE
Use row-major matrices and remove CPU transposes

### DIFF
--- a/EngineBaseDir/Shaders/common_blocks.glsl
+++ b/EngineBaseDir/Shaders/common_blocks.glsl
@@ -1,12 +1,12 @@
-layout(std140, binding = 0) uniform FrameBlock {
+layout(std140, row_major, binding = 0) uniform FrameBlock {
     mat4 uViewProj;
     vec3 uCameraWS; float uTime;
 };
-layout(std140, binding = 1) uniform ObjectBlock {
+layout(std140, row_major, binding = 1) uniform ObjectBlock {
     mat4 uWorld;
     mat4 uNormalWorld;
 };
-layout(std140, binding = 2) uniform MaterialBlock {
+layout(std140, row_major, binding = 2) uniform MaterialBlock {
     vec4  uBaseColorFactor;
     float uMetallic;
     float uRoughness;

--- a/EngineBaseDir/Shaders/standard.vert
+++ b/EngineBaseDir/Shaders/standard.vert
@@ -1,9 +1,9 @@
 out VS_OUT { vec3 P; vec3 N; vec2 UV; } vs;
 void main()
 {
-    vec4 wp = vec4(inPos, 1.0) * uWorld;
+    vec4 wp = uWorld * vec4(inPos, 1.0);
     vs.P  = wp.xyz;
-    vs.N  = normalize((vec4(inNormal, 0.0) * uNormalWorld).xyz);
+    vs.N  = normalize((uNormalWorld * vec4(inNormal, 0.0)).xyz);
     vs.UV = inUV;
-    gl_Position = wp * uViewProj;
+    gl_Position = uViewProj * wp;
 }

--- a/EngineBaseDir/Shaders/standard.vert
+++ b/EngineBaseDir/Shaders/standard.vert
@@ -1,9 +1,9 @@
 out VS_OUT { vec3 P; vec3 N; vec2 UV; } vs;
 void main()
 {
-    vec4 wp = uWorld * vec4(inPos, 1.0);
+    vec4 wp = vec4(inPos, 1.0) * uWorld;
     vs.P  = wp.xyz;
-    vs.N  = normalize((uNormalWorld * vec4(inNormal, 0.0)).xyz);
+    vs.N  = normalize((vec4(inNormal, 0.0) * uNormalWorld).xyz);
     vs.UV = inUV;
-    gl_Position = uViewProj * wp;
+    gl_Position = wp * uViewProj;
 }

--- a/src/Core/Camera.cs
+++ b/src/Core/Camera.cs
@@ -1,5 +1,4 @@
-using OpenTK.Windowing.Common;
-using OpenTK.Mathematics;
+using System.Numerics;
 using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace RenderMaster;
@@ -7,8 +6,8 @@ namespace RenderMaster;
 public class Camera
 {
     public Vector3 Position { get; set; }
-    public Matrix4 View { get; private set; }
-    public Matrix4 Projection { get; private set; }
+    public Matrix4x4 View { get; private set; }
+    public Matrix4x4 Projection { get; private set; }
 
     public float Yaw { get; private set; }
     public float Pitch { get; private set; }
@@ -30,8 +29,8 @@ public class Camera
     {
         Position = position;
         front = Vector3.Normalize(lookingAt - position);
-        Yaw = MathHelper.RadiansToDegrees(MathF.Atan2(front.Z, front.X));
-        Pitch = MathHelper.RadiansToDegrees(MathF.Asin(front.Y));
+        Yaw = MathF.Atan2(front.Z, front.X) * (180f / MathF.PI);
+        Pitch = MathF.Asin(front.Y) * (180f / MathF.PI);
         UpdateCameraVectors();
         SetPerspectiveProjection(fieldOfView, aspectRatio, nearPlane, farPlane);
         UpdateViewMatrix();
@@ -39,7 +38,7 @@ public class Camera
 
     public void UpdateViewMatrix()
     {
-        View = Matrix4.LookAt(Position, Position + front, up);
+        View = Matrix4x4.CreateLookAt(Position, Position + front, up);
     }
 
     public void SetPerspectiveProjection(float fieldOfView, float aspectRatio, float nearPlane, float farPlane)
@@ -53,7 +52,7 @@ public class Camera
 
     public void UpdateProjection()
     {
-        Projection = Matrix4.CreatePerspectiveFieldOfView(FieldOfView, AspectRatio, NearPlane, FarPlane);
+        Projection = Matrix4x4.CreatePerspectiveFieldOfView(FieldOfView, AspectRatio, NearPlane, FarPlane);
     }
 
     public void UpdateAspectRatio(float aspectRatio)
@@ -65,9 +64,11 @@ public class Camera
     void UpdateCameraVectors()
     {
         Vector3 f;
-        f.X = MathF.Cos(MathHelper.DegreesToRadians(Yaw)) * MathF.Cos(MathHelper.DegreesToRadians(Pitch));
-        f.Y = MathF.Sin(MathHelper.DegreesToRadians(Pitch));
-        f.Z = MathF.Sin(MathHelper.DegreesToRadians(Yaw)) * MathF.Cos(MathHelper.DegreesToRadians(Pitch));
+        float radYaw = Yaw * (MathF.PI / 180f);
+        float radPitch = Pitch * (MathF.PI / 180f);
+        f.X = MathF.Cos(radYaw) * MathF.Cos(radPitch);
+        f.Y = MathF.Sin(radPitch);
+        f.Z = MathF.Sin(radYaw) * MathF.Cos(radPitch);
         front = Vector3.Normalize(f);
         right = Vector3.Normalize(Vector3.Cross(front, Vector3.UnitY));
         up = Vector3.Normalize(Vector3.Cross(right, front));
@@ -102,7 +103,7 @@ public class Camera
 
         Yaw += deltaX;
         Pitch += InvertY ? deltaY : -deltaY;
-        Pitch = MathHelper.Clamp(Pitch, -89f, 89f);
+        Pitch = MathF.Clamp(Pitch, -89f, 89f);
 
         UpdateCameraVectors();
         UpdateViewMatrix();

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -36,7 +36,7 @@ public class Game : GameWindow
         Title = title
     })
     {
-        camera = new Camera(new OpenTK.Mathematics.Vector3(2, 0, 0), new OpenTK.Mathematics.Vector3(0, 0, 0),
+        camera = new Camera(new Vector3(2, 0, 0), new Vector3(0, 0, 0),
             0.8f, (float)width / height, 1, 4000);
         input = new Input(this, camera);
     }
@@ -105,14 +105,8 @@ public class Game : GameWindow
         GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 
         // Build frame constants and render scene
-        static Matrix4x4 ToNum(OpenTK.Mathematics.Matrix4 m) =>
-            new(m.M11, m.M12, m.M13, m.M14,
-                m.M21, m.M22, m.M23, m.M24,
-                m.M31, m.M32, m.M33, m.M34,
-                m.M41, m.M42, m.M43, m.M44);
-
-        var view = ToNum(camera.View);
-        var proj = ToNum(camera.Projection);
+        var view = camera.View;
+        var proj = camera.Projection;
 
         static bool MatrixHasNaN(in Matrix4x4 m) =>
             !(float.IsFinite(m.M11) && float.IsFinite(m.M22) && float.IsFinite(m.M33) && float.IsFinite(m.M44));
@@ -120,13 +114,13 @@ public class Game : GameWindow
         if (MatrixHasNaN(view) || MatrixHasNaN(proj))
             RenderMaster.Engine.Logger.Log($"NaN in view/proj! view={view} proj={proj}", RenderMaster.Engine.LogLevel.Error);
 
-        // correct for GLSL column-major consuming VP in the shader
-        var viewProj = Matrix4x4.Transpose(view * proj);
+        // Compose projection and view for column-vector math in GLSL
+        var viewProj = proj * view;
 
         var frame = new FrameBlock
         {
             ViewProj = viewProj,
-            CameraWS = new Vector3(camera.Position.X, camera.Position.Y, camera.Position.Z),
+            CameraWS = camera.Position,
             Time = (float)GLFW.GetTime()
         };
 

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -60,6 +60,8 @@ public class Game : GameWindow
             RenderMaster.Engine.Logger.Log($"GL DEBUG [{severity}] {type}/{src} #{id}: {txt}", RenderMaster.Engine.LogLevel.Debug);
         }, IntPtr.Zero);
 
+        GL.ClipControl(ClipOrigin.LowerLeft, ClipDepthMode.ZeroToOne);
+
         RenderMaster.Engine.Logger.Log(
             $"GL_VENDOR={GL.GetString(StringName.Vendor)} GL_RENDERER={GL.GetString(StringName.Renderer)} GL_VERSION={GL.GetString(StringName.Version)}",
             RenderMaster.Engine.LogLevel.Info);

--- a/src/NewGraphics/Frame/DrawEncoder.cs
+++ b/src/NewGraphics/Frame/DrawEncoder.cs
@@ -101,7 +101,7 @@ namespace RenderMaster.src.NewGraphics.Frame
         public static Matrix4x4 ComputeNormalWorld(Matrix4x4 world)
         {
             Matrix4x4.Invert(world, out var inv);
-            return inv;
+            return Matrix4x4.Transpose(inv);
         }
 
         private static void BindPassState(PassKind pass)

--- a/src/NewGraphics/Frame/DrawEncoder.cs
+++ b/src/NewGraphics/Frame/DrawEncoder.cs
@@ -67,8 +67,8 @@ namespace RenderMaster.src.NewGraphics.Frame
 
                 var ob = new ObjectBlock
                 {
-                    World = Matrix4x4.Transpose(d.Packet.World),
-                    NormalWorld = Matrix4x4.Transpose(computeNormalWorld(d.Packet.World))
+                    World = d.Packet.World,
+                    NormalWorld = computeNormalWorld(d.Packet.World)
                 };
                 if (float.IsNaN(ob.World.M11) || float.IsNaN(ob.NormalWorld.M11))
                     RenderMaster.Engine.Logger.Log("ObjectBlock contains NaNs (world/normalWorld).", RenderMaster.Engine.LogLevel.Error);

--- a/src/NewGraphics/Frame/DrawEncoder.cs
+++ b/src/NewGraphics/Frame/DrawEncoder.cs
@@ -101,8 +101,7 @@ namespace RenderMaster.src.NewGraphics.Frame
         public static Matrix4x4 ComputeNormalWorld(Matrix4x4 world)
         {
             Matrix4x4.Invert(world, out var inv);
-            var nm = Matrix4x4.Transpose(inv);
-            return nm;
+            return inv;
         }
 
         private static void BindPassState(PassKind pass)

--- a/src/Physics/PhysicsObject.cs
+++ b/src/Physics/PhysicsObject.cs
@@ -1,4 +1,4 @@
-using OpenTK.Mathematics;
+using System.Numerics;
 
 namespace RenderMaster.src.Physics
 {


### PR DESCRIPTION
## Summary
- Switch shader uniform blocks to `row_major` layout and upload matrices without CPU-side transposition.
- Compute view-projection as `proj * view` and send camera position directly using System.Numerics structures.
- Refactor camera and draw encoder to rely on `System.Numerics.Matrix4x4`, simplifying normal matrix calculation.

## Testing
- ⚠️ `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a4dd1a6883269e115d0aaa37ce38