### PR TITLE
Fix vertex winding and re-enable backface culling

### DIFF
--- a/src/NewGraphics/Frame/DrawEncoder.cs
+++ b/src/NewGraphics/Frame/DrawEncoder.cs
@@ -115,8 +115,8 @@ namespace RenderMaster.src.NewGraphics.Frame
                     GL.Disable(EnableCap.Blend);
                     GL.Enable(EnableCap.DepthTest);
                     GL.DepthMask(true);
-                    //GL.Enable(EnableCap.CullFace);
-                    //GL.CullFace(CullFaceMode.Back);
+                    GL.Enable(EnableCap.CullFace);
+                    GL.CullFace(CullFaceMode.Back);
                     GL.ColorMask(true, true, true, true);
                     break;
 

--- a/src/NewGraphics/Resources/PreparedMeshBuffer.cs
+++ b/src/NewGraphics/Resources/PreparedMeshBuffer.cs
@@ -106,6 +106,12 @@ namespace RenderMaster.src.NewGraphics.Resources
                 baseVertex += (uint)positions.Count;
             }
 
+            // Flip winding order to match OpenGL's default counter-clockwise convention
+            for (int i = 0; i + 2 < idx32.Count; i += 3)
+            {
+                (idx32[i + 2], idx32[i + 1]) = (idx32[i + 1], idx32[i + 2]);
+            }
+
             // Finalize
             Vertices = verts.ToArray();
             VertexCount = Vertices.Length / FloatsPerVertex;


### PR DESCRIPTION
## Summary
- flip triangle index order when loading meshes
- restore back-face culling for opaque pass

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5081e176883269b15dc30f1d02629