### PR TITLE
Implement hierarchical scene graph with local/world transforms

### DIFF
--- a/src/NewGraphics/Frame/DrawExtractor.cs
+++ b/src/NewGraphics/Frame/DrawExtractor.cs
@@ -15,11 +15,12 @@ namespace RenderMaster.src.NewGraphics.Frame
         // Extract + classify in one pass to avoid re-lookups.
         public static List<ClassifiedDraw> Build(LoadedNodes nodes, CPUResourceTable cpu, UploadResult map)
         {
+            nodes.UpdateWorldTransforms();
             var draws = new List<ClassifiedDraw>(capacity: 256);
 
-            foreach (var node in nodes.All)
+            void Traverse(Node node)
             {
-                var xf = node.GetComponent<TransformComponent>()?.Transform ?? Matrix4x4.Identity;
+                var xf = node.GetComponent<TransformComponent>()?.WorldTransform ?? Matrix4x4.Identity;
                 foreach (var mc in node.GetComponents<MeshComponent>())
                 {
                     var meshGpu = map.Map(mc.Mesh);
@@ -35,7 +36,13 @@ namespace RenderMaster.src.NewGraphics.Frame
 
                     draws.Add(new ClassifiedDraw(packet, tech, pass, pipeline));
                 }
+
+                foreach (var child in node.Children)
+                    Traverse(child);
             }
+
+            foreach (var root in nodes.All)
+                Traverse(root);
 
             return draws;
         }

--- a/src/NewGraphics/Loading/LoadFromGltfFile.cs
+++ b/src/NewGraphics/Loading/LoadFromGltfFile.cs
@@ -79,12 +79,11 @@ namespace RenderMaster.src.NewGraphics.Loading
                 meshMap[mesh] = (meshHandle, prepared.Submeshes.ToArray());
             }
 
-            void ConvertNode(SharpGLTF.Schema2.Node src, Matrix4x4 parentWorld)
+            SceneNode ConvertNode(SharpGLTF.Schema2.Node src)
             {
                 var local = src.LocalMatrix;
-                var world = parentWorld * local;
                 var node = new SceneNode();
-                node.AddComponent(new TransformComponent(world));
+                node.AddComponent(new TransformComponent(local));
 
                 if (src.Mesh != null && meshMap.TryGetValue(src.Mesh, out var meshInfo))
                 {
@@ -100,14 +99,20 @@ namespace RenderMaster.src.NewGraphics.Loading
                     }
                 }
 
-                Nodes.AddNode(node);
-
                 foreach (var child in src.VisualChildren)
-                    ConvertNode(child, world);
+                {
+                    var c = ConvertNode(child);
+                    node.AddChild(c);
+                }
+
+                return node;
             }
 
             foreach (var root in model.LogicalNodes.Where(n => n.VisualParent == null))
-                ConvertNode(root, Matrix4x4.Identity);
+            {
+                var n = ConvertNode(root);
+                Nodes.AddNode(n);
+            }
         }
     }
 }

--- a/src/NewGraphics/Scene/LoadedNodes.cs
+++ b/src/NewGraphics/Scene/LoadedNodes.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Numerics;
 
 namespace RenderMaster.src.NewGraphics.Scene
 {
@@ -12,5 +13,25 @@ namespace RenderMaster.src.NewGraphics.Scene
 
         // Expose a read-only view for traversal during extraction.
         public IReadOnlyList<Node> All => nodes;
+
+        public void UpdateWorldTransforms()
+        {
+            foreach (var root in nodes)
+                UpdateRecursive(root, Matrix4x4.Identity);
+        }
+
+        static void UpdateRecursive(Node node, Matrix4x4 parentWorld)
+        {
+            var tc = node.GetComponent<TransformComponent>();
+            var world = parentWorld;
+            if (tc != null)
+            {
+                world = parentWorld * tc.LocalTransform;
+                tc.WorldTransform = world;
+            }
+
+            foreach (var child in node.Children)
+                UpdateRecursive(child, world);
+        }
     }
 }

--- a/src/NewGraphics/Scene/Node.cs
+++ b/src/NewGraphics/Scene/Node.cs
@@ -13,10 +13,13 @@ namespace RenderMaster.src.NewGraphics.Scene
 
     class TransformComponent : INodeComponent
     {
-        public Matrix4x4 Transform { get; set; }
-        public TransformComponent(Matrix4x4 transform)
+        public Matrix4x4 LocalTransform { get; set; }
+        public Matrix4x4 WorldTransform { get; set; }
+
+        public TransformComponent(Matrix4x4 localTransform)
         {
-            Transform = transform;
+            LocalTransform = localTransform;
+            WorldTransform = localTransform;
         }
     }
 
@@ -37,8 +40,18 @@ namespace RenderMaster.src.NewGraphics.Scene
     class Node
     {
         readonly List<INodeComponent> _components = new();
+        readonly List<Node> _children = new();
+
+        public Node? Parent { get; private set; }
+        public IReadOnlyList<Node> Children => _children;
 
         public void AddComponent(INodeComponent comp) => _components.Add(comp);
+
+        public void AddChild(Node child)
+        {
+            child.Parent = this;
+            _children.Add(child);
+        }
 
         public IEnumerable<T> GetComponents<T>() where T : class, INodeComponent
             => _components.OfType<T>();


### PR DESCRIPTION
## Summary
- introduce parent-child relationships to scene nodes and store local & world transforms
- compute world transforms per frame and traverse hierarchy when extracting draws
- load glTF nodes preserving hierarchy and local transforms

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b50f4596308326a88253585e111a08