### PR TITLE
Clarify DrawExtractor root traversal

### DIFF
--- a/src/NewGraphics/Frame/DrawExtractor.cs
+++ b/src/NewGraphics/Frame/DrawExtractor.cs
@@ -40,6 +40,7 @@ namespace RenderMaster.src.NewGraphics.Frame
                     Traverse(child);
             }
 
+            // Begin traversal from scene roots so each node is processed once.
             foreach (var root in nodes.Roots)
                 Traverse(root);
 

--- a/src/NewGraphics/Scene/LoadedNodes.cs
+++ b/src/NewGraphics/Scene/LoadedNodes.cs
@@ -24,7 +24,7 @@ namespace RenderMaster.src.NewGraphics.Scene
         // Flat list of every node for systems that need random access.
         public IReadOnlyList<Node> All => _all;
 
-        // Top-level roots for hierarchy traversal.
+        // Only the top-level nodes. Begin traversals here to avoid duplicates.
         public IReadOnlyList<Node> Roots => _roots;
 
         public void UpdateWorldTransforms()


### PR DESCRIPTION
## Summary
- document traversal starting from scene roots in DrawExtractor
- clarify LoadedNodes roots accessor for proper hierarchy traversal

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5144c2b4c8326bf19cb81317b60a4