### PR TITLE
Handle sRGB textures correctly

### DIFF
--- a/EngineBaseDir/Shaders/pbr.frag
+++ b/EngineBaseDir/Shaders/pbr.frag
@@ -113,7 +113,5 @@ void main()
     vec3 ambient = vec3(0.03) * albedo.rgb;
     vec3 color = ambient + Lo;
     color = color / (color + vec3(1.0)); // Basic Reinhard tone mapping
-    color = pow(color, vec3(1.0/2.2));   // Gamma correction
-    
     outColor = vec4(color, albedo.a);
 }

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -90,6 +90,8 @@ public class Game : GameWindow
         }
 
         GL.Enable(EnableCap.DepthTest);
+        // Enable automatic sRGB conversion when writing to the default framebuffer
+        GL.Enable(EnableCap.FramebufferSrgb);
 
         // Ensure the initial frame uses the correct framebuffer size and aspect
         // ratio. On some high-DPI systems the first render can occur before a

--- a/src/NewGraphics/Loading/LoadFromGltfFile.cs
+++ b/src/NewGraphics/Loading/LoadFromGltfFile.cs
@@ -49,7 +49,11 @@ namespace RenderMaster.src.NewGraphics.Loading
                     material.BaseColorFactor = baseColor.Value.Color;
                     var bc = baseColor.Value.Texture;
                     if (bc != null && texMap.TryGetValue(bc, out var bcHandle))
+                    {
                         material.Textures["BaseColorTexture"] = bcHandle;
+                        // Base color textures are encoded in sRGB space
+                        table.Textures[bcHandle.Id].IsSrgb = true;
+                    }
                 }
 
                 var mrChan = mat.FindChannel("MetallicRoughness");
@@ -60,12 +64,20 @@ namespace RenderMaster.src.NewGraphics.Loading
 
                     var mr = mrChan.Value.Texture;
                     if (mr != null && texMap.TryGetValue(mr, out var mrHandle))
+                    {
                         material.Textures["MetallicRoughnessTexture"] = mrHandle;
+                        // Metallic-roughness textures should remain in linear space
+                        table.Textures[mrHandle.Id].IsSrgb = false;
+                    }
                 }
 
                 var normal = mat.FindChannel("Normal")?.Texture;
                 if (normal != null && texMap.TryGetValue(normal, out var nHandle))
+                {
                     material.Textures["NormalTexture"] = nHandle;
+                    // Normal maps also use linear color space
+                    table.Textures[nHandle.Id].IsSrgb = false;
+                }
 
                 var mHandle = table.AddMaterial(material);
                 matMap[mat] = mHandle;

--- a/src/NewGraphics/Resources/GPUResourceTable.cs
+++ b/src/NewGraphics/Resources/GPUResourceTable.cs
@@ -100,7 +100,8 @@ namespace RenderMaster.src.NewGraphics.Resources
         public TextureHandle CreateTexture(PreparedTexture cpu, SamplerDesc sampler)
         {
             GL.CreateTextures(TextureTarget.Texture2D, 1, out int tex);
-            GL.TextureStorage2D(tex, 1, SizedInternalFormat.Rgba8, cpu.Width, cpu.Height);
+            var internalFmt = cpu.IsSrgb ? SizedInternalFormat.Srgb8Alpha8 : SizedInternalFormat.Rgba8;
+            GL.TextureStorage2D(tex, 1, internalFmt, cpu.Width, cpu.Height);
             GL.TextureSubImage2D(tex, 0, 0, 0, cpu.Width, cpu.Height, PixelFormat.Rgba, PixelType.UnsignedByte, cpu.Pixels);
 
             GL.CreateSamplers(1, out int samp);

--- a/src/NewGraphics/Resources/PreparedTexture.cs
+++ b/src/NewGraphics/Resources/PreparedTexture.cs
@@ -10,13 +10,20 @@ namespace RenderMaster.src.NewGraphics.Resources
         public int Height { get; }
         public byte[] Pixels { get; } = Array.Empty<byte>();
 
-        public PreparedTexture(byte[] bytes)
+        // Indicates whether the texture data is encoded in sRGB color space.
+        // Color textures like albedo/base color maps should be sRGB, while
+        // data textures (normal maps, metallic-roughness, etc.) should remain
+        // linear.
+        public bool IsSrgb { get; set; }
+
+        public PreparedTexture(byte[] bytes, bool isSrgb = true)
         {
             using var ms = new MemoryStream(bytes);
             var img = ImageResult.FromStream(ms, ColorComponents.RedGreenBlueAlpha);
             Width = img.Width;
             Height = img.Height;
             Pixels = img.Data;
+            IsSrgb = isSrgb;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Encode color textures as sRGB when uploading to GPU and enable hardware framebuffer gamma
- Mark material textures with correct color space (base color sRGB, normals and metallic/roughness linear)
- Drop manual pow() gamma correction from PBR fragment shader

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b68e291ccc832691f09832fa6ab0dd