### PR TITLE
Implement shader hot reloading via file watchers

### DIFF
--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -29,6 +29,7 @@ public class Game : GameWindow
     ProgramLibrary programs = new();
     ProgramUniforms uniforms = null!;
     LoadedNodes nodes = new();
+    private ShaderHotReloader _shaderReloader = null!;
 
     public Game(int width, int height, string title) : base(GameWindowSettings.Default, new NativeWindowSettings()
     {
@@ -75,6 +76,8 @@ public class Game : GameWindow
         // Initialize GL-dependent uniform buffers once context is ready
         uniforms = new ProgramUniforms();
 
+        _shaderReloader = new ShaderHotReloader(EngineConfig.ShaderDirectory);
+
         // Load a glTF scene if available
         var modelPath = Path.Combine(EngineConfig.ModelDirectory, "AdvancedScene\\dungeon.glb");
         if (File.Exists(modelPath))
@@ -115,6 +118,7 @@ public class Game : GameWindow
     protected override void OnUpdateFrame(FrameEventArgs args)
     {
         base.OnUpdateFrame(args);
+        _shaderReloader.ProcessChanges(programs);
         input.Update(args);
         userInterface.Update(args, camera, input.MouseGrabbed);
 
@@ -167,6 +171,12 @@ public class Game : GameWindow
 
         userInterface.Render();
         SwapBuffers();
+    }
+
+    protected override void OnUnload()
+    {
+        _shaderReloader.Dispose();
+        base.OnUnload();
     }
 
     protected override void OnKeyDown(KeyboardKeyEventArgs e) => input.OnKeyDown(e);

--- a/src/NewGraphics/Programs/ProgramLibrary.cs
+++ b/src/NewGraphics/Programs/ProgramLibrary.cs
@@ -1,18 +1,34 @@
 using OpenTK.Graphics.OpenGL4;
 using System.Collections.Generic;
+using System.IO;
+
 namespace RenderMaster.src.NewGraphics.Programs
 {
     sealed class ProgramLibrary
     {
         readonly Dictionary<ProgramKey, ShaderProgram> _cache = new();
+        readonly Dictionary<string, HashSet<ProgramKey>> _fileDependencies = new();
+
         public ShaderProgram Get(ProgramKey key)
         {
             if (_cache.TryGetValue(key, out var p)) return p;
-            RenderMaster.Engine.Logger.Log($"Program cache miss: {key}", RenderMaster.Engine.LogLevel.Debug);
-            var (v, f) = ShaderSources.For(key);
+            RenderMaster.Engine.Logger.Log($"Program cache miss, compiling: {key}", RenderMaster.Engine.LogLevel.Debug);
+
+            var (v, f, deps) = ShaderSources.For(key);
             var prog = new ShaderProgram(v, f);
             BindStaticLayouts(prog.Handle);
             _cache[key] = prog;
+
+            foreach (var depPath in deps)
+            {
+                if (!_fileDependencies.TryGetValue(depPath, out var set))
+                {
+                    set = new HashSet<ProgramKey>();
+                    _fileDependencies[depPath] = set;
+                }
+                set.Add(key);
+            }
+
             return prog;
         }
 
@@ -35,6 +51,27 @@ namespace RenderMaster.src.NewGraphics.Programs
             SetSampler("uBaseColorTex",         TextureUnits.BaseColor);
             SetSampler("uNormalTex",            TextureUnits.Normal);
             SetSampler("uMetalRoughTex",        TextureUnits.MetallicRoughness);
+        }
+
+        public void InvalidateProgramsUsingFile(string filePath)
+        {
+            if (_fileDependencies.TryGetValue(filePath, out var affectedKeys))
+            {
+                RenderMaster.Engine.Logger.Log(
+                    $"Invalidating {affectedKeys.Count} programs due to change in {Path.GetFileName(filePath)}",
+                    RenderMaster.Engine.LogLevel.Info);
+
+                foreach (var key in affectedKeys)
+                {
+                    if (_cache.TryGetValue(key, out var program))
+                    {
+                        program.Dispose();
+                        _cache.Remove(key);
+                    }
+                }
+
+                affectedKeys.Clear();
+            }
         }
     }
 }

--- a/src/NewGraphics/Programs/ShaderHotReloader.cs
+++ b/src/NewGraphics/Programs/ShaderHotReloader.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+
+namespace RenderMaster.src.NewGraphics.Programs
+{
+    class ShaderHotReloader : IDisposable
+    {
+        private readonly FileSystemWatcher _watcher;
+        private readonly ConcurrentQueue<string> _changedFiles = new();
+
+        public ShaderHotReloader(string shaderDirectory)
+        {
+            _watcher = new FileSystemWatcher(shaderDirectory)
+            {
+                NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName,
+                IncludeSubdirectories = true,
+                EnableRaisingEvents = true
+            };
+
+            _watcher.Changed += OnFileChanged;
+            _watcher.Created += OnFileChanged;
+            _watcher.Renamed += OnFileChanged;
+        }
+
+        private void OnFileChanged(object sender, FileSystemEventArgs e)
+        {
+            if (e.Name.EndsWith(".glsl") || e.Name.EndsWith(".vert") || e.Name.EndsWith(".frag"))
+            {
+                if (!_changedFiles.Contains(e.FullPath))
+                {
+                    _changedFiles.Enqueue(e.FullPath);
+                    RenderMaster.Engine.Logger.Log($"Shader file changed: {e.Name}", RenderMaster.Engine.LogLevel.Info);
+                }
+            }
+        }
+
+        public void ProcessChanges(ProgramLibrary programLibrary)
+        {
+            while (_changedFiles.TryDequeue(out var filePath))
+            {
+                programLibrary.InvalidateProgramsUsingFile(filePath);
+            }
+        }
+
+        public void Dispose() => _watcher.Dispose();
+    }
+}

--- a/src/NewGraphics/Programs/ShaderSources.cs
+++ b/src/NewGraphics/Programs/ShaderSources.cs
@@ -1,9 +1,11 @@
+using System.Collections.Generic;
 using System.IO;
+
 namespace RenderMaster.src.NewGraphics.Programs
 {
     static class ShaderSources
     {
-        public static (string vert, string frag) For(ProgramKey key)
+        public static (string vert, string frag, List<string> dependencies) For(ProgramKey key)
         {
             var defs =
 $@"#version 450 core
@@ -12,9 +14,19 @@ $@"#version 450 core
 {(key.Variants.HasFlag(ProgramVariants.DoubleSided) ? "#define VAR_DOUBLESIDED 1" : "")}
 {(key.Variants.HasFlag(ProgramVariants.AlphaBlend)  ? "#define VAR_ALPHABLEND 1" : "")}
 ";
+
             string dir = EngineConfig.ShaderDirectory;
-            string common = File.ReadAllText(Path.Combine(dir, "common_blocks.glsl"));
-            string vert   = File.ReadAllText(Path.Combine(dir, "standard.vert"));
+
+            var dependencies = new List<string>();
+
+            string commonPath = Path.Combine(dir, "common_blocks.glsl");
+            dependencies.Add(commonPath);
+            string common = File.ReadAllText(commonPath);
+
+            string vertPath = Path.Combine(dir, "standard.vert");
+            dependencies.Add(vertPath);
+            string vert = File.ReadAllText(vertPath);
+
             string fragFile;
             switch (key.Tech)
             {
@@ -27,10 +39,13 @@ $@"#version 450 core
                     fragFile = "unlit.frag";
                     break;
             }
-            string frag = File.ReadAllText(Path.Combine(dir, fragFile));
+
+            string fragPath = Path.Combine(dir, fragFile);
+            dependencies.Add(fragPath);
+            string frag = File.ReadAllText(fragPath);
+
             //literally return a tuple containing the full shader
-            return ($"{defs}\n{common}\n{vert}", $"{defs}\n{common}\n{frag}");
+            return ($"{defs}\n{common}\n{vert}", $"{defs}\n{common}\n{frag}", dependencies);
         }
     }
 }
-//		frag	"in VS_OUT { vec3 P; vec3 N; vec2 UV; } fs;\r\nlayout(location=0) out vec4 outColor;\r\n\r\nuniform sampler2D uBaseColorTex;\r\n\r\nvoid main()\r\n{\r\n#ifdef VAR_ALPHABLEND\r\n    if (texture(uBaseColorTex, fs.UV).a < uAlphaCutoff) discard;\r\n#endif\r\n    vec4 bc = texture(uBaseColorTex, fs.UV) * uBaseColorFactor;\r\n    outColor = bc;\r\n}\r\n"	string


### PR DESCRIPTION
## Summary
- track shader file dependencies and invalidate programs using FileSystemWatcher
- wire hot reloader into game loop for automatic shader recompilation

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68b699df5e908326b7f7073aa28944af