### PR TITLE
Implement shader hot-reloading

### DIFF
--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -115,6 +115,7 @@ public class Game : GameWindow
     protected override void OnUpdateFrame(FrameEventArgs args)
     {
         base.OnUpdateFrame(args);
+        programs.PumpHotReload();
         input.Update(args);
         userInterface.Update(args, camera, input.MouseGrabbed);
 
@@ -132,8 +133,6 @@ public class Game : GameWindow
 
     protected override void OnRenderFrame(FrameEventArgs args)
     {
-        programs.PumpHotReload();
-
         GL.ClearColor(0.4f, 0.4f, 0.4f, 1.0f);
         GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 

--- a/src/Host/Program.cs
+++ b/src/Host/Program.cs
@@ -132,6 +132,8 @@ public class Game : GameWindow
 
     protected override void OnRenderFrame(FrameEventArgs args)
     {
+        programs.PumpHotReload();
+
         GL.ClearColor(0.4f, 0.4f, 0.4f, 1.0f);
         GL.Clear(ClearBufferMask.ColorBufferBit | ClearBufferMask.DepthBufferBit);
 

--- a/src/NewGraphics/Programs/ProgramLibrary.cs
+++ b/src/NewGraphics/Programs/ProgramLibrary.cs
@@ -1,19 +1,81 @@
 using OpenTK.Graphics.OpenGL4;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
+
 namespace RenderMaster.src.NewGraphics.Programs
 {
     sealed class ProgramLibrary
     {
         readonly Dictionary<ProgramKey, ShaderProgram> _cache = new();
+        readonly Dictionary<ProgramKey, string[]> _deps = new();
+        readonly ConcurrentQueue<string> _changes = new();
+        readonly FileSystemWatcher _watcher;
+
+        public ProgramLibrary()
+        {
+            _watcher = new FileSystemWatcher(EngineConfig.ShaderDirectory)
+            {
+                IncludeSubdirectories = true,
+                EnableRaisingEvents = true
+            };
+            _watcher.Changed += OnFileChanged;
+            _watcher.Created += OnFileChanged;
+            _watcher.Deleted += OnFileChanged;
+            _watcher.Renamed += (s, e) =>
+            {
+                _changes.Enqueue(e.FullPath);
+                _changes.Enqueue(e.OldFullPath);
+            };
+        }
+
+        void OnFileChanged(object? sender, FileSystemEventArgs e) => _changes.Enqueue(e.FullPath);
+
         public ShaderProgram Get(ProgramKey key)
         {
             if (_cache.TryGetValue(key, out var p)) return p;
             RenderMaster.Engine.Logger.Log($"Program cache miss: {key}", RenderMaster.Engine.LogLevel.Debug);
-            var (v, f) = ShaderSources.For(key);
+            var (v, f, deps) = ShaderSources.ForWithDeps(key);
             var prog = new ShaderProgram(v, f);
             BindStaticLayouts(prog.Handle);
             _cache[key] = prog;
+            _deps[key] = deps;
             return prog;
+        }
+
+        public void PumpHotReload()
+        {
+            if (_changes.IsEmpty) return;
+
+            HashSet<ProgramKey> dirty = new();
+            while (_changes.TryDequeue(out var path))
+            {
+                foreach (var (key, deps) in _deps)
+                {
+                    if (Array.IndexOf(deps, path) >= 0)
+                        dirty.Add(key);
+                }
+            }
+
+            foreach (var key in dirty)
+            {
+                if (!_cache.TryGetValue(key, out var oldProg))
+                    continue;
+                try
+                {
+                    var (v, f, deps) = ShaderSources.ForWithDeps(key);
+                    var prog = new ShaderProgram(v, f);
+                    BindStaticLayouts(prog.Handle);
+                    _cache[key] = prog;
+                    _deps[key] = deps;
+                    oldProg.Dispose();
+                    RenderMaster.Engine.Logger.Log($"Hot reloaded {key}", RenderMaster.Engine.LogLevel.Info);
+                }
+                catch (System.Exception ex)
+                {
+                    RenderMaster.Engine.Logger.Log($"Failed to hot reload {key}: {ex.Message}", RenderMaster.Engine.LogLevel.Error);
+                }
+            }
         }
 
         static void BindStaticLayouts(int prog)

--- a/src/NewGraphics/Programs/ShaderSources.cs
+++ b/src/NewGraphics/Programs/ShaderSources.cs
@@ -1,9 +1,23 @@
+using System.Collections.Generic;
 using System.IO;
+
 namespace RenderMaster.src.NewGraphics.Programs
 {
     static class ShaderSources
     {
+        static string ReadWithLine(string path)
+        {
+            string name = Path.GetFileName(path).Replace("\\", "/");
+            return $"#line 1 \"{name}\"\n{File.ReadAllText(path)}";
+        }
+
         public static (string vert, string frag) For(ProgramKey key)
+        {
+            var (v, f, _) = ForWithDeps(key);
+            return (v, f);
+        }
+
+        public static (string vert, string frag, string[] deps) ForWithDeps(ProgramKey key)
         {
             var defs =
 $@"#version 450 core
@@ -12,9 +26,18 @@ $@"#version 450 core
 {(key.Variants.HasFlag(ProgramVariants.DoubleSided) ? "#define VAR_DOUBLESIDED 1" : "")}
 {(key.Variants.HasFlag(ProgramVariants.AlphaBlend)  ? "#define VAR_ALPHABLEND 1" : "")}
 ";
+
             string dir = EngineConfig.ShaderDirectory;
-            string common = File.ReadAllText(Path.Combine(dir, "common_blocks.glsl"));
-            string vert   = File.ReadAllText(Path.Combine(dir, "standard.vert"));
+            List<string> deps = new();
+
+            string commonPath = Path.Combine(dir, "common_blocks.glsl");
+            deps.Add(commonPath);
+            string common = ReadWithLine(commonPath);
+
+            string vertPath = Path.Combine(dir, "standard.vert");
+            deps.Add(vertPath);
+            string vertBody = ReadWithLine(vertPath);
+
             string fragFile;
             switch (key.Tech)
             {
@@ -27,10 +50,16 @@ $@"#version 450 core
                     fragFile = "unlit.frag";
                     break;
             }
-            string frag = File.ReadAllText(Path.Combine(dir, fragFile));
-            //literally return a tuple containing the full shader
-            return ($"{defs}\n{common}\n{vert}", $"{defs}\n{common}\n{frag}");
+
+            string fragPath = Path.Combine(dir, fragFile);
+            deps.Add(fragPath);
+            string fragBody = ReadWithLine(fragPath);
+
+            string vert = $"{defs}\n{common}\n{vertBody}";
+            string frag = $"{defs}\n{common}\n{fragBody}";
+
+            return (vert, frag, deps.ToArray());
         }
     }
 }
-//		frag	"in VS_OUT { vec3 P; vec3 N; vec2 UV; } fs;\r\nlayout(location=0) out vec4 outColor;\r\n\r\nuniform sampler2D uBaseColorTex;\r\n\r\nvoid main()\r\n{\r\n#ifdef VAR_ALPHABLEND\r\n    if (texture(uBaseColorTex, fs.UV).a < uAlphaCutoff) discard;\r\n#endif\r\n    vec4 bc = texture(uBaseColorTex, fs.UV) * uBaseColorFactor;\r\n    outColor = bc;\r\n}\r\n"	string
+


### PR DESCRIPTION
## Summary
- Add shader source loader `ForWithDeps` that returns dependency list and uses `#line` for accurate error reporting
- Make `ProgramLibrary` track dependencies and rebuild shaders on file change using a watcher
- Pump hot reload from the GL thread each frame

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b756cbc6ac8326bb52c9543b44914e