### PR TITLE
Cache material blocks on write path

### DIFF
--- a/src/ControlPlane/EngineControl.cs
+++ b/src/ControlPlane/EngineControl.cs
@@ -155,6 +155,8 @@ public sealed class EngineControl : IDisposable
                 return;
             }
 
+            _cpu.UpdateMaterialBlock(cpuMatIndex);
+
             // Render path pulls factors from CPU into the MaterialBlock UBO next frame.
             Engine.Logger.Log($"SetMaterialParam: matCpu#{cpuMatIndex} {cmd.Param} = {cmd.Value}", Engine.LogLevel.Info);
         });

--- a/src/NewGraphics/Frame/DrawEncoder.cs
+++ b/src/NewGraphics/Frame/DrawEncoder.cs
@@ -18,8 +18,8 @@ namespace RenderMaster.src.NewGraphics.Frame
             GPUResourceTable gpu,
             ProgramLibrary programs,
             ProgramUniforms uniforms,
-            //So, materialBlockOf is a variable that holds a function. This function's job is to convert a GPU material handle into the actual data that needs to be uploaded for rendering.
-            Func<Handle<GPUResourceTable.MaterialGPU>, MaterialBlock> materialBlockOf)
+            UploadResult map,
+            IReadOnlyList<MaterialBlock> materialBlocks)
         {
             PassKind currentPass = (PassKind)(-1);
             int currentVao = -1;
@@ -53,7 +53,10 @@ namespace RenderMaster.src.NewGraphics.Frame
 
                 if (d.Packet.Material.IsValid && d.Packet.Material.Id != lastMaterialId)
                 {
-                    var mb = materialBlockOf(d.Packet.Material);
+                    int cpuId = (d.Packet.Material.Id < map.GpuToCpu_Mat.Length && map.GpuToCpu_Mat[d.Packet.Material.Id] >= 0)
+                        ? map.GpuToCpu_Mat[d.Packet.Material.Id]
+                        : 0;
+                    var mb = materialBlocks[cpuId];
                     var (buf, off) = uniforms.MaterialRing.Push(mb);
                     GL.BindBufferRange(BufferRangeTarget.UniformBuffer, BindingPoints.Material, buf, (IntPtr)off, 256);
                     lastMaterialId = d.Packet.Material.Id;

--- a/src/NewGraphics/Frame/RendererCore.cs
+++ b/src/NewGraphics/Frame/RendererCore.cs
@@ -39,24 +39,7 @@ namespace RenderMaster.src.NewGraphics.Frame
 
             DrawSorter.SortInPlace(draws);
 
-            DrawEncoder.EncodeAndDraw(
-                draws, gpu, programs, uniforms,
-                materialBlockOf: h =>
-                {
-                    int cpuId = (h.Id < map.GpuToCpu_Mat.Length && map.GpuToCpu_Mat[h.Id] >= 0)
-                        ? map.GpuToCpu_Mat[h.Id]
-                        : 0;
-                    var m = cpu.Materials[cpuId];
-                    var mb = new MaterialBlock
-                    {
-                        BaseColorFactor = m.BaseColorFactor ?? new Vector4(1, 1, 1, 1),
-                        Metallic = m.MetallicFactor ?? 1f,
-                        Roughness = m.RoughnessFactor ?? 1f,
-                        AlphaCutoff = 0.5f,
-                        Flags = 0f
-                    };
-                    return mb;
-                });
+            DrawEncoder.EncodeAndDraw(draws, gpu, programs, uniforms, map, cpu.MaterialBlocks);
         }
     }
 }

--- a/src/NewGraphics/Resources/CPUResourceTable.cs
+++ b/src/NewGraphics/Resources/CPUResourceTable.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using System.Numerics;
 using RenderMaster.src.NewGraphics.Types;
+using RenderMaster.src.NewGraphics.Programs;
 [assembly: InternalsVisibleTo("RenderMaster.src.ControlPlane")]
 namespace RenderMaster.src.NewGraphics.Resources
 {
@@ -13,10 +15,12 @@ namespace RenderMaster.src.NewGraphics.Resources
         List<PreparedMeshBuffer> meshBuffers = new List<PreparedMeshBuffer>();
         List<PreparedTexture> textures = new List<PreparedTexture>();
         List<MaterialCPU> materials = new List<MaterialCPU>();
+        List<MaterialBlock> materialBlocks = new List<MaterialBlock>();
 
         public IReadOnlyList<PreparedMeshBuffer> MeshBuffers => meshBuffers;
         public IReadOnlyList<PreparedTexture> Textures => textures;
         public IReadOnlyList<MaterialCPU> Materials => materials;
+        public IReadOnlyList<MaterialBlock> MaterialBlocks => materialBlocks;
 
         public MeshHandle AddMeshBuffer(PreparedMeshBuffer buffer)
         {
@@ -33,8 +37,23 @@ namespace RenderMaster.src.NewGraphics.Resources
         public MaterialHandle AddMaterial(MaterialCPU mat)
         {
             materials.Add(mat);
+            materialBlocks.Add(ToBlock(mat));
             return new MaterialHandle(materials.Count - 1);
         }
+
+        public void UpdateMaterialBlock(int index)
+        {
+            materialBlocks[index] = ToBlock(materials[index]);
+        }
+
+        static MaterialBlock ToBlock(MaterialCPU m) => new MaterialBlock
+        {
+            BaseColorFactor = m.BaseColorFactor ?? new Vector4(1, 1, 1, 1),
+            Metallic = m.MetallicFactor ?? 1f,
+            Roughness = m.RoughnessFactor ?? 1f,
+            AlphaCutoff = 0.5f,
+            Flags = 0f,
+        };
     }
 }
 


### PR DESCRIPTION
## Summary
- Precompute GPU material blocks when materials are added or modified
- Pass cached material blocks directly to the draw encoder
- Update material parameter command to refresh precomputed blocks

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bb81059f60832683a38fa3997c4892