### PR TITLE
Implement glTF punctual lighting support

### DIFF
--- a/EngineBaseDir/Shaders/common_blocks.glsl
+++ b/EngineBaseDir/Shaders/common_blocks.glsl
@@ -14,3 +14,20 @@ layout(std140, binding = 2) uniform MaterialBlock {
     float uFlags;
 };
 
+struct GPUPointLight {
+    vec4 positionRange;
+    vec4 colorIntensity;
+};
+
+struct GPUSpotLight {
+    vec4 positionRange;
+    vec4 directionInner;
+    vec4 colorOuter;
+};
+
+layout(std140, binding = 3) uniform LightBlock {
+    vec4 uLightCounts; // x = point, y = spot
+    GPUPointLight uPointLights[MAX_POINT_LIGHTS];
+    GPUSpotLight uSpotLights[MAX_SPOT_LIGHTS];
+};
+

--- a/EngineBaseDir/Shaders/pbr.frag
+++ b/EngineBaseDir/Shaders/pbr.frag
@@ -60,6 +60,32 @@ vec3 fresnelSchlick(float cosTheta, vec3 F0)
 }
 // --- End PBR Functions ---
 
+vec3 EvaluateLight(
+    vec3 N,
+    vec3 V,
+    vec3 L,
+    vec3 radiance,
+    vec3 F0,
+    vec3 albedo,
+    float metallic,
+    float roughness)
+{
+    vec3 H = normalize(V + L);
+    float NDF = DistributionGGX(N, H, roughness);
+    float G = GeometrySmith(N, V, L, roughness);
+    vec3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
+
+    vec3 numerator = NDF * G * F;
+    float denominator = 4.0 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + 0.0001;
+    vec3 specular = numerator / denominator;
+
+    vec3 kS = F;
+    vec3 kD = (vec3(1.0) - kS) * (1.0 - metallic);
+    float NdotL = max(dot(N, L), 0.0);
+
+    return (kD * albedo / PI + specular) * radiance * NdotL;
+}
+
 void main()
 {
     // --- Material Properties ---
@@ -67,46 +93,83 @@ void main()
     vec4 albedo = texture(uBaseColorTex, fs.UV) * uBaseColorFactor;
     float metallic = texture(uMetalRoughTex, fs.UV).b * uMetallic;
     float roughness = texture(uMetalRoughTex, fs.UV).g * uRoughness;
-    
+    metallic = clamp(metallic, 0.0, 1.0);
+    roughness = clamp(roughness, 0.04, 1.0);
+
     // --- Vectors ---
     vec3 N = normalize(fs.N);
     vec3 V = normalize(uCameraWS - fs.P);
 
     // F0 is the base reflectivity for a surface at a 0-degree angle.
     // For metals, F0 is the albedo color. For dielectrics (non-metals), it's a constant.
-    vec3 F0 = vec3(0.04); 
+    vec3 F0 = vec3(0.04);
     F0 = mix(F0, albedo.rgb, metallic);
 
-    // --- Lighting (using a simple hardcoded directional light for now) ---
     vec3 Lo = vec3(0.0); // Outgoing radiance (the final color)
-    vec3 lightPos = uCameraWS;
-    vec3 lightColor = 150.0 * (0.5 + 0.5 * cos(2.0 * PI * uTime + vec3(0.0, 2.0*PI/3.0, 4.0*PI/3.0)));
-    
-    // Light calculation
-    vec3 L = normalize(lightPos - fs.P);
-    vec3 H = normalize(V + L);
-    float distance = length(lightPos - fs.P);
-    float attenuation = 1.0 / (distance * distance);
-    vec3 radiance = lightColor * attenuation;
-        
-    // --- Cook-Torrance Bidirectional Reflectance Distribution Function (BRDF) ---
-    float NDF = DistributionGGX(N, H, roughness);   
-    float G = GeometrySmith(N, V, L, roughness);      
-    vec3 F = fresnelSchlick(max(dot(H, V), 0.0), F0);
-    
-    // Specular BRDF component
-    vec3 numerator = NDF * G * F;
-    float denominator = 4.0 * max(dot(N, V), 0.0) * max(dot(N, L), 0.0) + 0.0001; // 0.0001 to prevent division by zero
-    vec3 specular = numerator / denominator;
-    
-    // kS is the Fresnel value, determining the ratio of specular to diffuse reflection
-    vec3 kS = F;
-    // kD is the remaining light, used for diffuse reflection.
-    vec3 kD = vec3(1.0) - kS;
-    kD *= 1.0 - metallic; // Metals absorb all refracted light, so they have no diffuse color.
-     
-    float NdotL = max(dot(N, L), 0.0);        
-    Lo += (kD * albedo.rgb / PI + specular) * radiance * NdotL;
+    // Camera-attached helper light (legacy behavior)
+    vec3 cameraToLight = uCameraWS - fs.P;
+    float cameraDist = length(cameraToLight);
+    if (cameraDist > 0.0001)
+    {
+        vec3 lightColor = 150.0 * (0.5 + 0.5 * cos(2.0 * PI * uTime + vec3(0.0, 2.0*PI/3.0, 4.0*PI/3.0)));
+        vec3 L = cameraToLight / cameraDist;
+        float attenuation = 1.0 / max(cameraDist * cameraDist, 0.0001);
+        vec3 radiance = lightColor * attenuation;
+        Lo += EvaluateLight(N, V, L, radiance, F0, albedo.rgb, metallic, roughness);
+    }
+
+    int pointCount = int(uLightCounts.x + 0.5);
+    for (int i = 0; i < pointCount; ++i)
+    {
+        GPUPointLight light = uPointLights[i];
+        vec3 toLight = light.positionRange.xyz - fs.P;
+        float dist = length(toLight);
+        if (dist <= 0.0001) continue;
+
+        vec3 L = toLight / dist;
+        float attenuation = 1.0 / max(dist * dist, 0.0001);
+        float range = light.positionRange.w;
+        if (range > 0.0)
+        {
+            float rangeFactor = clamp(1.0 - dist / range, 0.0, 1.0);
+            attenuation *= rangeFactor * rangeFactor;
+        }
+
+        vec3 radiance = light.colorIntensity.rgb * attenuation;
+        Lo += EvaluateLight(N, V, L, radiance, F0, albedo.rgb, metallic, roughness);
+    }
+
+    int spotCount = int(uLightCounts.y + 0.5);
+    for (int i = 0; i < spotCount; ++i)
+    {
+        GPUSpotLight light = uSpotLights[i];
+        vec3 toLight = light.positionRange.xyz - fs.P;
+        float dist = length(toLight);
+        if (dist <= 0.0001) continue;
+
+        vec3 L = toLight / dist;
+        float attenuation = 1.0 / max(dist * dist, 0.0001);
+        float range = light.positionRange.w;
+        if (range > 0.0)
+        {
+            float rangeFactor = clamp(1.0 - dist / range, 0.0, 1.0);
+            attenuation *= rangeFactor * rangeFactor;
+        }
+
+        vec3 dir = light.directionInner.xyz;
+        float dirLen = length(dir);
+        if (dirLen <= 0.0001) continue;
+        dir /= dirLen;
+
+        float cosTheta = dot(dir, -L);
+        float inner = light.directionInner.w;
+        float outer = light.colorOuter.w;
+        float spotFactor = smoothstep(outer, inner, cosTheta);
+        attenuation *= spotFactor;
+
+        vec3 radiance = light.colorOuter.rgb * attenuation;
+        Lo += EvaluateLight(N, V, L, radiance, F0, albedo.rgb, metallic, roughness);
+    }
 
     // --- Final Color ---
     // Add a simple ambient term and apply tone mapping

--- a/src/ControlPlane/DebugProjection.cs
+++ b/src/ControlPlane/DebugProjection.cs
@@ -91,6 +91,8 @@ sealed class DebugProjection : IProjection, IDebugProjectionReader
         var tags = new List<string>(3);
         if (n.GetComponent<TransformComponent>() != null) tags.Add("Transform");
         foreach (var _ in n.GetComponents<MeshComponent>()) tags.Add("Mesh");
+        if (n.GetComponent<PointLightComponent>() != null) tags.Add("PointLight");
+        if (n.GetComponent<SpotLightComponent>() != null) tags.Add("SpotLight");
         return tags.ToArray();
     }
 
@@ -130,6 +132,34 @@ sealed class DebugProjection : IProjection, IDebugProjectionReader
                     new PropertyDescriptor("HasBaseColorTex", "bool", HasTex(cpu, mc.Material, "BaseColorTexture")),
                     new PropertyDescriptor("HasNormalTex", "bool", HasTex(cpu, mc.Material, "NormalTexture")),
                     new PropertyDescriptor("HasMetalRoughTex", "bool", HasTex(cpu, mc.Material, "MetallicRoughnessTexture")),
+                }));
+        }
+
+        foreach (var plc in n.GetComponents<PointLightComponent>())
+        {
+            list.Add(new ComponentDescriptor(
+                "PointLight",
+                new[]
+                {
+                    new PropertyDescriptor("Color", "vec3", plc.Color),
+                    new PropertyDescriptor("Intensity", "float", plc.Intensity),
+                    new PropertyDescriptor("Range", "float", plc.Range),
+                }));
+        }
+
+        foreach (var slc in n.GetComponents<SpotLightComponent>())
+        {
+            float innerDeg = slc.InnerConeAngle * (180f / MathF.PI);
+            float outerDeg = slc.OuterConeAngle * (180f / MathF.PI);
+            list.Add(new ComponentDescriptor(
+                "SpotLight",
+                new[]
+                {
+                    new PropertyDescriptor("Color", "vec3", slc.Color),
+                    new PropertyDescriptor("Intensity", "float", slc.Intensity),
+                    new PropertyDescriptor("Range", "float", slc.Range),
+                    new PropertyDescriptor("InnerCone", "float", innerDeg),
+                    new PropertyDescriptor("OuterCone", "float", outerDeg),
                 }));
         }
 

--- a/src/NewGraphics/Frame/LightExtractor.cs
+++ b/src/NewGraphics/Frame/LightExtractor.cs
@@ -108,8 +108,9 @@ namespace RenderMaster.src.NewGraphics.Frame
 
             unsafe
             {
-                fixed (PointLightGpu* dest = block.PointLights)
+                fixed (float* pointPtr = block.PointLights)
                 {
+                    var dest = (PointLightGpu*)pointPtr;
                     for (int i = 0; i < pointCount; i++)
                     {
                         var src = lights.Points[i];
@@ -126,8 +127,9 @@ namespace RenderMaster.src.NewGraphics.Frame
                         dest[i] = default;
                 }
 
-                fixed (SpotLightGpu* dest = block.SpotLights)
+                fixed (float* spotPtr = block.SpotLights)
                 {
+                    var dest = (SpotLightGpu*)spotPtr;
                     for (int i = 0; i < spotCount; i++)
                     {
                         var src = lights.Spots[i];

--- a/src/NewGraphics/Frame/LightExtractor.cs
+++ b/src/NewGraphics/Frame/LightExtractor.cs
@@ -88,7 +88,7 @@ namespace RenderMaster.src.NewGraphics.Frame
         static bool pointWarningIssued;
         static bool spotWarningIssued;
 
-        public static LightBlock BuildBlock(in PreparedLights lights)
+        public static unsafe LightBlock BuildBlock(in PreparedLights lights)
         {
             var block = new LightBlock();
 
@@ -132,7 +132,7 @@ namespace RenderMaster.src.NewGraphics.Frame
             return block;
         }
 
-        static void WritePoint(ref LightBlock block, int index, in PreparedPointLight src)
+        static unsafe void WritePoint(ref LightBlock block, int index, in PreparedPointLight src)
         {
             float range = src.Range > 0f ? src.Range : -1f;
             var colorIntensity = src.Color * src.Intensity;
@@ -149,7 +149,7 @@ namespace RenderMaster.src.NewGraphics.Frame
             block.PointLights[baseIndex + 7] = src.Intensity;
         }
 
-        static void ClearPointTail(ref LightBlock block, int startIndex)
+        static unsafe void ClearPointTail(ref LightBlock block, int startIndex)
         {
             int start = startIndex * LightBlock.PointLightFloatCount;
             int end = LightingLimits.MaxPointLights * LightBlock.PointLightFloatCount;
@@ -157,7 +157,7 @@ namespace RenderMaster.src.NewGraphics.Frame
                 block.PointLights[i] = 0f;
         }
 
-        static void WriteSpot(ref LightBlock block, int index, in PreparedSpotLight src)
+        static unsafe void WriteSpot(ref LightBlock block, int index, in PreparedSpotLight src)
         {
             float range = src.Range > 0f ? src.Range : -1f;
             var colorIntensity = src.Color * src.Intensity;
@@ -179,7 +179,7 @@ namespace RenderMaster.src.NewGraphics.Frame
             block.SpotLights[baseIndex + 11] = src.OuterConeCos;
         }
 
-        static void ClearSpotTail(ref LightBlock block, int startIndex)
+        static unsafe void ClearSpotTail(ref LightBlock block, int startIndex)
         {
             int start = startIndex * LightBlock.SpotLightFloatCount;
             int end = LightingLimits.MaxSpotLights * LightBlock.SpotLightFloatCount;

--- a/src/NewGraphics/Frame/LightExtractor.cs
+++ b/src/NewGraphics/Frame/LightExtractor.cs
@@ -68,11 +68,18 @@ namespace RenderMaster.src.NewGraphics.Frame
 
         static (float innerCos, float outerCos) ComputeCone(float inner, float outer)
         {
-            float clampedInner = MathF.Clamp(inner, 0f, MathF.PI * 0.5f);
-            float clampedOuter = MathF.Clamp(outer, 0f, MathF.PI * 0.5f);
+            float clampedInner = Clamp(inner, 0f, MathF.PI * 0.5f);
+            float clampedOuter = Clamp(outer, 0f, MathF.PI * 0.5f);
             if (clampedOuter < clampedInner)
                 clampedOuter = clampedInner;
             return (MathF.Cos(clampedInner), MathF.Cos(clampedOuter));
+        }
+
+        static float Clamp(float value, float min, float max)
+        {
+            if (value < min) return min;
+            if (value > max) return max;
+            return value;
         }
     }
 
@@ -106,50 +113,78 @@ namespace RenderMaster.src.NewGraphics.Frame
 
             block.Counts = new Vector4(pointCount, spotCount, 0f, 0f);
 
-            unsafe
+            for (int i = 0; i < pointCount; i++)
             {
-                fixed (float* pointPtr = block.PointLights)
-                {
-                    var dest = (PointLightGpu*)pointPtr;
-                    for (int i = 0; i < pointCount; i++)
-                    {
-                        var src = lights.Points[i];
-                        float range = src.Range > 0f ? src.Range : -1f;
-                        var colorIntensity = src.Color * src.Intensity;
-                        dest[i] = new PointLightGpu
-                        {
-                            PositionRange = new Vector4(src.Position, range),
-                            ColorIntensity = new Vector4(colorIntensity, src.Intensity)
-                        };
-                    }
-
-                    for (int i = pointCount; i < LightingLimits.MaxPointLights; i++)
-                        dest[i] = default;
-                }
-
-                fixed (float* spotPtr = block.SpotLights)
-                {
-                    var dest = (SpotLightGpu*)spotPtr;
-                    for (int i = 0; i < spotCount; i++)
-                    {
-                        var src = lights.Spots[i];
-                        float range = src.Range > 0f ? src.Range : -1f;
-                        var colorIntensity = src.Color * src.Intensity;
-                        var dir = src.Direction;
-                        dest[i] = new SpotLightGpu
-                        {
-                            PositionRange = new Vector4(src.Position, range),
-                            DirectionInner = new Vector4(dir, src.InnerConeCos),
-                            ColorOuter = new Vector4(colorIntensity, src.OuterConeCos)
-                        };
-                    }
-
-                    for (int i = spotCount; i < LightingLimits.MaxSpotLights; i++)
-                        dest[i] = default;
-                }
+                var src = lights.Points[i];
+                WritePoint(ref block, i, src);
             }
 
+            ClearPointTail(ref block, pointCount);
+
+            for (int i = 0; i < spotCount; i++)
+            {
+                var src = lights.Spots[i];
+                WriteSpot(ref block, i, src);
+            }
+
+            ClearSpotTail(ref block, spotCount);
+
             return block;
+        }
+
+        static void WritePoint(ref LightBlock block, int index, in PreparedPointLight src)
+        {
+            float range = src.Range > 0f ? src.Range : -1f;
+            var colorIntensity = src.Color * src.Intensity;
+            int baseIndex = index * LightBlock.PointLightFloatCount;
+
+            block.PointLights[baseIndex + 0] = src.Position.X;
+            block.PointLights[baseIndex + 1] = src.Position.Y;
+            block.PointLights[baseIndex + 2] = src.Position.Z;
+            block.PointLights[baseIndex + 3] = range;
+
+            block.PointLights[baseIndex + 4] = colorIntensity.X;
+            block.PointLights[baseIndex + 5] = colorIntensity.Y;
+            block.PointLights[baseIndex + 6] = colorIntensity.Z;
+            block.PointLights[baseIndex + 7] = src.Intensity;
+        }
+
+        static void ClearPointTail(ref LightBlock block, int startIndex)
+        {
+            int start = startIndex * LightBlock.PointLightFloatCount;
+            int end = LightingLimits.MaxPointLights * LightBlock.PointLightFloatCount;
+            for (int i = start; i < end; i++)
+                block.PointLights[i] = 0f;
+        }
+
+        static void WriteSpot(ref LightBlock block, int index, in PreparedSpotLight src)
+        {
+            float range = src.Range > 0f ? src.Range : -1f;
+            var colorIntensity = src.Color * src.Intensity;
+            int baseIndex = index * LightBlock.SpotLightFloatCount;
+
+            block.SpotLights[baseIndex + 0] = src.Position.X;
+            block.SpotLights[baseIndex + 1] = src.Position.Y;
+            block.SpotLights[baseIndex + 2] = src.Position.Z;
+            block.SpotLights[baseIndex + 3] = range;
+
+            block.SpotLights[baseIndex + 4] = src.Direction.X;
+            block.SpotLights[baseIndex + 5] = src.Direction.Y;
+            block.SpotLights[baseIndex + 6] = src.Direction.Z;
+            block.SpotLights[baseIndex + 7] = src.InnerConeCos;
+
+            block.SpotLights[baseIndex + 8] = colorIntensity.X;
+            block.SpotLights[baseIndex + 9] = colorIntensity.Y;
+            block.SpotLights[baseIndex + 10] = colorIntensity.Z;
+            block.SpotLights[baseIndex + 11] = src.OuterConeCos;
+        }
+
+        static void ClearSpotTail(ref LightBlock block, int startIndex)
+        {
+            int start = startIndex * LightBlock.SpotLightFloatCount;
+            int end = LightingLimits.MaxSpotLights * LightBlock.SpotLightFloatCount;
+            for (int i = start; i < end; i++)
+                block.SpotLights[i] = 0f;
         }
     }
 }

--- a/src/NewGraphics/Frame/LightExtractor.cs
+++ b/src/NewGraphics/Frame/LightExtractor.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using RenderMaster.Engine;
+using RenderMaster.src.NewGraphics.Programs;
+using RenderMaster.src.NewGraphics.Scene;
+
+namespace RenderMaster.src.NewGraphics.Frame
+{
+    readonly record struct PreparedPointLight(Vector3 Position, Vector3 Color, float Intensity, float Range);
+
+    readonly record struct PreparedSpotLight(
+        Vector3 Position,
+        Vector3 Direction,
+        Vector3 Color,
+        float Intensity,
+        float Range,
+        float InnerConeCos,
+        float OuterConeCos);
+
+    readonly struct PreparedLights
+    {
+        public PreparedLights(List<PreparedPointLight> points, List<PreparedSpotLight> spots)
+        {
+            Points = points;
+            Spots = spots;
+        }
+
+        public IReadOnlyList<PreparedPointLight> Points { get; }
+        public IReadOnlyList<PreparedSpotLight> Spots { get; }
+    }
+
+    static class LightExtractor
+    {
+        public static PreparedLights Build(LoadedNodes nodes)
+        {
+            var points = new List<PreparedPointLight>();
+            var spots = new List<PreparedSpotLight>();
+
+            foreach (var node in nodes.All)
+            {
+                var world = node.GetComponent<TransformComponent>()?.WorldTransform ?? Matrix4x4.Identity;
+                var position = world.Translation;
+
+                foreach (var pl in node.GetComponents<PointLightComponent>())
+                {
+                    points.Add(new PreparedPointLight(position, pl.Color, pl.Intensity, pl.Range));
+                }
+
+                foreach (var sl in node.GetComponents<SpotLightComponent>())
+                {
+                    var direction = ExtractDirection(world);
+                    var (innerCos, outerCos) = ComputeCone(sl.InnerConeAngle, sl.OuterConeAngle);
+                    spots.Add(new PreparedSpotLight(position, direction, sl.Color, sl.Intensity, sl.Range, innerCos, outerCos));
+                }
+            }
+
+            return new PreparedLights(points, spots);
+        }
+
+        static Vector3 ExtractDirection(Matrix4x4 world)
+        {
+            var dir = Vector3.TransformNormal(-Vector3.UnitZ, world);
+            if (dir.LengthSquared() < 1e-6f)
+                return -Vector3.UnitZ;
+            return Vector3.Normalize(dir);
+        }
+
+        static (float innerCos, float outerCos) ComputeCone(float inner, float outer)
+        {
+            float clampedInner = MathF.Clamp(inner, 0f, MathF.PI * 0.5f);
+            float clampedOuter = MathF.Clamp(outer, 0f, MathF.PI * 0.5f);
+            if (clampedOuter < clampedInner)
+                clampedOuter = clampedInner;
+            return (MathF.Cos(clampedInner), MathF.Cos(clampedOuter));
+        }
+    }
+
+    static class LightEncoder
+    {
+        static bool pointWarningIssued;
+        static bool spotWarningIssued;
+
+        public static LightBlock BuildBlock(in PreparedLights lights)
+        {
+            var block = new LightBlock();
+
+            int pointCount = Math.Min(lights.Points.Count, LightingLimits.MaxPointLights);
+            int spotCount = Math.Min(lights.Spots.Count, LightingLimits.MaxSpotLights);
+
+            if (lights.Points.Count > LightingLimits.MaxPointLights && !pointWarningIssued)
+            {
+                Logger.Log(
+                    $"Truncating point lights: supported={LightingLimits.MaxPointLights} requested={lights.Points.Count}",
+                    LogLevel.Warning);
+                pointWarningIssued = true;
+            }
+
+            if (lights.Spots.Count > LightingLimits.MaxSpotLights && !spotWarningIssued)
+            {
+                Logger.Log(
+                    $"Truncating spot lights: supported={LightingLimits.MaxSpotLights} requested={lights.Spots.Count}",
+                    LogLevel.Warning);
+                spotWarningIssued = true;
+            }
+
+            block.Counts = new Vector4(pointCount, spotCount, 0f, 0f);
+
+            unsafe
+            {
+                fixed (PointLightGpu* dest = block.PointLights)
+                {
+                    for (int i = 0; i < pointCount; i++)
+                    {
+                        var src = lights.Points[i];
+                        float range = src.Range > 0f ? src.Range : -1f;
+                        var colorIntensity = src.Color * src.Intensity;
+                        dest[i] = new PointLightGpu
+                        {
+                            PositionRange = new Vector4(src.Position, range),
+                            ColorIntensity = new Vector4(colorIntensity, src.Intensity)
+                        };
+                    }
+
+                    for (int i = pointCount; i < LightingLimits.MaxPointLights; i++)
+                        dest[i] = default;
+                }
+
+                fixed (SpotLightGpu* dest = block.SpotLights)
+                {
+                    for (int i = 0; i < spotCount; i++)
+                    {
+                        var src = lights.Spots[i];
+                        float range = src.Range > 0f ? src.Range : -1f;
+                        var colorIntensity = src.Color * src.Intensity;
+                        var dir = src.Direction;
+                        dest[i] = new SpotLightGpu
+                        {
+                            PositionRange = new Vector4(src.Position, range),
+                            DirectionInner = new Vector4(dir, src.InnerConeCos),
+                            ColorOuter = new Vector4(colorIntensity, src.OuterConeCos)
+                        };
+                    }
+
+                    for (int i = spotCount; i < LightingLimits.MaxSpotLights; i++)
+                        dest[i] = default;
+                }
+            }
+
+            return block;
+        }
+    }
+}

--- a/src/NewGraphics/Frame/RendererCore.cs
+++ b/src/NewGraphics/Frame/RendererCore.cs
@@ -16,6 +16,11 @@ namespace RenderMaster.src.NewGraphics.Frame
             uniforms.Frame.Update(frame);
             uniforms.Frame.Bind(BindingPoints.Frame);
 
+            var preparedLights = LightExtractor.Build(nodes);
+            var lightBlock = LightEncoder.BuildBlock(preparedLights);
+            uniforms.Lights.Update(lightBlock);
+            uniforms.Lights.Bind(BindingPoints.Lights);
+
             //returns a list of draws, classified by technique and pass, for best drawing order
             var draws = DrawExtractor.Build(nodes, cpu, map);
             if (draws.Count == 0)

--- a/src/NewGraphics/Loading/LoadFromGltfFile.cs
+++ b/src/NewGraphics/Loading/LoadFromGltfFile.cs
@@ -91,12 +91,49 @@ namespace RenderMaster.src.NewGraphics.Loading
                 meshMap[mesh] = (meshHandle, prepared.Submeshes.ToArray());
             }
 
+            int pointLightCount = 0;
+            int spotLightCount = 0;
+            int skippedLightCount = 0;
+
             SceneNode ConvertNode(SharpGLTF.Schema2.Node src)
             {
                 var local = src.LocalMatrix;
                 var node = new SceneNode();
                 node.AddComponent(new NameComponent(src.Name ?? "(unnamed)"));
                 node.AddComponent(new TransformComponent(local));
+
+                var punctual = src.PunctualLight;
+                if (punctual != null)
+                {
+                    var color = punctual.Color;
+                    var intensity = punctual.Intensity;
+                    var range = punctual.Range.HasValue ? punctual.Range.Value : -1f;
+
+                    switch (punctual.LightType)
+                    {
+                        case SharpGLTF.Schema2.PunctualLightType.Point:
+                            node.AddComponent(new PointLightComponent(color, intensity, range));
+                            pointLightCount++;
+                            break;
+
+                        case SharpGLTF.Schema2.PunctualLightType.Spot:
+                        {
+                            var spot = punctual.Spot;
+                            float inner = spot?.InnerConeAngle ?? 0f;
+                            float outer = spot?.OuterConeAngle ?? (MathF.PI / 4f);
+                            node.AddComponent(new SpotLightComponent(color, intensity, range, inner, outer));
+                            spotLightCount++;
+                            break;
+                        }
+
+                        default:
+                            skippedLightCount++;
+                            RenderMaster.Engine.Logger.Log(
+                                $"Skipping unsupported light '{punctual.LightType}' on node '{src.Name ?? "(unnamed)"}'",
+                                RenderMaster.Engine.LogLevel.Warning);
+                            break;
+                    }
+                }
 
                 if (src.Mesh != null && meshMap.TryGetValue(src.Mesh, out var meshInfo))
                 {
@@ -125,6 +162,13 @@ namespace RenderMaster.src.NewGraphics.Loading
             {
                 var n = ConvertNode(root);
                 Nodes.AddNode(n);
+            }
+
+            if (pointLightCount > 0 || spotLightCount > 0 || skippedLightCount > 0)
+            {
+                RenderMaster.Engine.Logger.Log(
+                    $"Loaded lights: point={pointLightCount} spot={spotLightCount} skipped={skippedLightCount}",
+                    RenderMaster.Engine.LogLevel.Info);
             }
         }
     }

--- a/src/NewGraphics/Loading/LoadFromGltfFile.cs
+++ b/src/NewGraphics/Loading/LoadFromGltfFile.cs
@@ -107,7 +107,7 @@ namespace RenderMaster.src.NewGraphics.Loading
                 {
                     var color = punctual.Color;
                     var intensity = punctual.Intensity;
-                    var range = punctual.Range.HasValue ? punctual.Range.Value : -1f;
+                    var range = NormalizeLightRange(punctual.Range);
 
                     switch (punctual.LightType)
                     {
@@ -170,6 +170,13 @@ namespace RenderMaster.src.NewGraphics.Loading
                     $"Loaded lights: point={pointLightCount} spot={spotLightCount} skipped={skippedLightCount}",
                     RenderMaster.Engine.LogLevel.Info);
             }
+        }
+
+        static float NormalizeLightRange(float rawRange)
+        {
+            if (rawRange > 0f && !float.IsNaN(rawRange) && !float.IsInfinity(rawRange))
+                return rawRange;
+            return -1f;
         }
     }
 }

--- a/src/NewGraphics/Loading/LoadFromGltfFile.cs
+++ b/src/NewGraphics/Loading/LoadFromGltfFile.cs
@@ -118,9 +118,10 @@ namespace RenderMaster.src.NewGraphics.Loading
 
                         case SharpGLTF.Schema2.PunctualLightType.Spot:
                         {
-                            var spot = punctual.Spot;
-                            float inner = spot?.InnerConeAngle ?? 0f;
-                            float outer = spot?.OuterConeAngle ?? (MathF.PI / 4f);
+                            float inner = punctual.InnerConeAngle;
+                            float outer = punctual.OuterConeAngle;
+                            if (outer <= 0f)
+                                outer = MathF.PI / 4f;
                             node.AddComponent(new SpotLightComponent(color, intensity, range, inner, outer));
                             spotLightCount++;
                             break;

--- a/src/NewGraphics/Programs/ProgramLibrary.cs
+++ b/src/NewGraphics/Programs/ProgramLibrary.cs
@@ -88,6 +88,7 @@ namespace RenderMaster.src.NewGraphics.Programs
             Bind("FrameBlock",    BindingPoints.Frame);
             Bind("ObjectBlock",   BindingPoints.Object);
             Bind("MaterialBlock", BindingPoints.Material);
+            Bind("LightBlock",    BindingPoints.Lights);
 
             void SetSampler(string name, int unit)
             {

--- a/src/NewGraphics/Programs/ProgramUniforms.cs
+++ b/src/NewGraphics/Programs/ProgramUniforms.cs
@@ -7,12 +7,14 @@ namespace RenderMaster.src.NewGraphics.Programs
         public readonly UboRing<ObjectBlock> ObjectRing;
         public readonly UboRing<MaterialBlock> MaterialRing;
         public readonly UniformBuffer<FrameBlock> Frame;
+        public readonly UniformBuffer<LightBlock> Lights;
 
         public ProgramUniforms(int objectPerFrame = 65_536, int materialsPerFrame = 4_096)
         {
             ObjectRing = new UboRing<ObjectBlock>(objectPerFrame);
             MaterialRing = new UboRing<MaterialBlock>(materialsPerFrame);
             Frame = new UniformBuffer<FrameBlock>();
+            Lights = new UniformBuffer<LightBlock>();
         }
 
         public void BeginFrame() { ObjectRing.BeginFrame(); MaterialRing.BeginFrame(); }
@@ -22,6 +24,7 @@ namespace RenderMaster.src.NewGraphics.Programs
             ObjectRing.Dispose();
             MaterialRing.Dispose();
             Frame.Dispose();
+            Lights.Dispose();
         }
     }
 }

--- a/src/NewGraphics/Programs/ShaderSources.cs
+++ b/src/NewGraphics/Programs/ShaderSources.cs
@@ -23,6 +23,8 @@ namespace RenderMaster.src.NewGraphics.Programs
 $@"#version 450 core
 #define TECH_{key.Tech} 1
 #define PASS_{key.Pass} 1
+#define MAX_POINT_LIGHTS {LightingLimits.MaxPointLights}
+#define MAX_SPOT_LIGHTS {LightingLimits.MaxSpotLights}
 {(key.Variants.HasFlag(ProgramVariants.DoubleSided) ? "#define VAR_DOUBLESIDED 1" : "")}
 {(key.Variants.HasFlag(ProgramVariants.AlphaBlend)  ? "#define VAR_ALPHABLEND 1" : "")}
 ";

--- a/src/NewGraphics/Programs/UniformBlocks.cs
+++ b/src/NewGraphics/Programs/UniformBlocks.cs
@@ -3,6 +3,12 @@ using System.Runtime.InteropServices;
 
 namespace RenderMaster.src.NewGraphics.Programs
 {
+    internal static class LightingLimits
+    {
+        public const int MaxPointLights = 32;
+        public const int MaxSpotLights = 16;
+    }
+
     [StructLayout(LayoutKind.Sequential, Pack = 16)]
     struct FrameBlock
     {
@@ -25,5 +31,28 @@ namespace RenderMaster.src.NewGraphics.Programs
         public float Roughness;
         public float AlphaCutoff;
         public float Flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 16)]
+    struct PointLightGpu
+    {
+        public Vector4 PositionRange;
+        public Vector4 ColorIntensity;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 16)]
+    struct SpotLightGpu
+    {
+        public Vector4 PositionRange;
+        public Vector4 DirectionInner;
+        public Vector4 ColorOuter;
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 16)]
+    unsafe struct LightBlock
+    {
+        public Vector4 Counts;
+        public fixed PointLightGpu PointLights[LightingLimits.MaxPointLights];
+        public fixed SpotLightGpu SpotLights[LightingLimits.MaxSpotLights];
     }
 }

--- a/src/NewGraphics/Programs/UniformBlocks.cs
+++ b/src/NewGraphics/Programs/UniformBlocks.cs
@@ -51,8 +51,11 @@ namespace RenderMaster.src.NewGraphics.Programs
     [StructLayout(LayoutKind.Sequential, Pack = 16)]
     unsafe struct LightBlock
     {
+        public const int PointLightFloatCount = 8;   // 2 * vec4
+        public const int SpotLightFloatCount = 12;   // 3 * vec4
+
         public Vector4 Counts;
-        public fixed PointLightGpu PointLights[LightingLimits.MaxPointLights];
-        public fixed SpotLightGpu SpotLights[LightingLimits.MaxSpotLights];
+        public fixed float PointLights[LightingLimits.MaxPointLights * PointLightFloatCount];
+        public fixed float SpotLights[LightingLimits.MaxSpotLights * SpotLightFloatCount];
     }
 }

--- a/src/NewGraphics/Scene/Node.cs
+++ b/src/NewGraphics/Scene/Node.cs
@@ -43,6 +43,38 @@ namespace RenderMaster.src.NewGraphics.Scene
         }
     }
 
+    class PointLightComponent : INodeComponent
+    {
+        public Vector3 Color { get; }
+        public float Intensity { get; }
+        public float Range { get; }
+
+        public PointLightComponent(Vector3 color, float intensity, float range)
+        {
+            Color = color;
+            Intensity = intensity;
+            Range = range;
+        }
+    }
+
+    class SpotLightComponent : INodeComponent
+    {
+        public Vector3 Color { get; }
+        public float Intensity { get; }
+        public float Range { get; }
+        public float InnerConeAngle { get; }
+        public float OuterConeAngle { get; }
+
+        public SpotLightComponent(Vector3 color, float intensity, float range, float innerConeAngle, float outerConeAngle)
+        {
+            Color = color;
+            Intensity = intensity;
+            Range = range;
+            InnerConeAngle = innerConeAngle;
+            OuterConeAngle = outerConeAngle;
+        }
+    }
+
     class Node
     {
         readonly List<INodeComponent> _components = new();


### PR DESCRIPTION
## Summary
- load glTF point and spot lights into scene nodes and surface them to the debug projection
- collect punctual lights each frame and upload a light uniform block for GPU access
- update the PBR shader to evaluate point and spot lights while keeping the existing camera light

## Testing
- `dotnet build` *(fails: dotnet is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8852013248326b710787ea05af332