### PR TITLE
Add physics-based character controller with noclip toggle

### DIFF
--- a/src/Core/Camera.cs
+++ b/src/Core/Camera.cs
@@ -26,6 +26,10 @@ public class Camera
     Vector3 up = Vector3.UnitY;
     Vector3 right = Vector3.UnitX;
 
+    public Vector3 Front => front;
+    public Vector3 Up => up;
+    public Vector3 Right => right;
+
     public Camera(Vector3 position, Vector3 lookingAt, float fieldOfView, float aspectRatio, float nearPlane, float farPlane)
     {
         Position = position;

--- a/src/Core/Engine.cs
+++ b/src/Core/Engine.cs
@@ -53,7 +53,8 @@ public sealed class Engine : IDisposable
 
         _uniforms = new ProgramUniforms();
 
-        _physics = new PhysicsEngine();
+        var initialPlayerPosition = new System.Numerics.Vector3(_camera.Position.X, _camera.Position.Y, _camera.Position.Z);
+        _physics = new PhysicsEngine(initialPlayerPosition);
 
         _control = new EngineControl(
             _programs, _nodes, _cpu, _gpu, _map);
@@ -107,7 +108,24 @@ public sealed class Engine : IDisposable
 
         _input.Update(args);
 
-        _physics.Update(args, (float)args.Time);
+        if (_input.RequestedCharacterSnap)
+        {
+            var cameraPosition = _camera.Position;
+            _physics.Player.TeleportToMatchCamera(new System.Numerics.Vector3(cameraPosition.X, cameraPosition.Y, cameraPosition.Z));
+            _input.AcknowledgeCharacterSnap();
+            _input.SetMode(MovementMode.Character);
+            _input.SetMouseGrab(true);
+        }
+
+        var inputState = _input.State;
+        _physics.Update((float)args.Time, inputState, _camera.Front, _camera.Right);
+
+        if (inputState.Mode == MovementMode.Character)
+        {
+            var eye = _physics.Player.EyeWorldPosition;
+            _camera.Position = new OpenTK.Mathematics.Vector3(eye.X, eye.Y, eye.Z);
+            _camera.UpdateViewMatrix();
+        }
 
         _userInterface.Update(args, _camera, _input.MouseGrabbed);
 

--- a/src/Host/Input.cs
+++ b/src/Host/Input.cs
@@ -2,6 +2,7 @@ using ImGuiNET;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
 using OpenTK.Windowing.GraphicsLibraryFramework;
+using System.Numerics;
 
 namespace RenderMaster;
 
@@ -15,6 +16,15 @@ public class Input
 
     public bool MouseGrabbed { get; private set; } = false;
 
+    public MovementMode Mode { get; private set; } = MovementMode.Noclip;
+    public bool RequestedCharacterSnap { get; private set; }
+    bool _previousJumpDown;
+    Vector2 _movement;
+    bool _jumpPressed;
+    bool _jumpHeld;
+    bool _sprintHeld;
+    InputState _state;
+
     public Input(GameWindow window, Camera camera)
     {
         this.window = window;
@@ -25,7 +35,18 @@ public class Input
     {
         if (MouseGrabbed)
         {
-            camera.ProcessKeyboard(window.KeyboardState, (float)args.Time);
+            if (Mode == MovementMode.Noclip)
+            {
+                camera.ProcessKeyboard(window.KeyboardState, (float)args.Time);
+                _movement = Vector2.Zero;
+                _jumpPressed = false;
+                _jumpHeld = false;
+                _sprintHeld = false;
+            }
+            else
+            {
+                GatherCharacterInput();
+            }
 
             if (_accumulatedDeltaX != 0 || _accumulatedDeltaY != 0)
             {
@@ -34,6 +55,16 @@ public class Input
                 _accumulatedDeltaY = 0f;
             }
         }
+        else
+        {
+            _movement = Vector2.Zero;
+            _jumpPressed = false;
+            _jumpHeld = false;
+            _sprintHeld = false;
+            _previousJumpDown = false;
+        }
+
+        RebuildState();
     }
 
     public void OnKeyDown(KeyboardKeyEventArgs e)
@@ -47,9 +78,24 @@ public class Input
         io.AddKeyEvent(ImGuiKey.ModAlt, e.Alt);
         io.AddKeyEvent(ImGuiKey.ModSuper, e.Modifiers.HasFlag(KeyModifiers.Super));
 
-        if (e.Key == Keys.Z && !e.IsRepeat)
+        if (!e.IsRepeat)
         {
-            ToggleMouseGrab();
+            switch (e.Key)
+            {
+                case Keys.Z:
+                    Mode = Mode == MovementMode.Noclip ? MovementMode.Character : MovementMode.Noclip;
+                    if (!MouseGrabbed)
+                        ToggleMouseGrab();
+                    break;
+                case Keys.X:
+                    RequestedCharacterSnap = true;
+                    Mode = MovementMode.Character;
+                    break;
+                case Keys.Escape:
+                    if (MouseGrabbed)
+                        ToggleMouseGrab();
+                    break;
+            }
         }
     }
 
@@ -104,6 +150,33 @@ public class Input
         camera.ProcessMouseScroll(e.OffsetY);
     }
 
+    public void AcknowledgeCharacterSnap()
+    {
+        RequestedCharacterSnap = false;
+    }
+
+    public void SetMode(MovementMode mode)
+    {
+        Mode = mode;
+        RebuildState();
+    }
+
+    public void SetMouseGrab(bool grab)
+    {
+        if (MouseGrabbed != grab)
+        {
+            ToggleMouseGrab();
+        }
+        RebuildState();
+    }
+
+    public InputState State => _state;
+
+    public void RebuildState()
+    {
+        _state = new InputState(Mode, MouseGrabbed, _movement, _jumpPressed, _jumpHeld, _sprintHeld);
+    }
+
     private void ToggleMouseGrab()
     {
         MouseGrabbed = !MouseGrabbed;
@@ -117,6 +190,34 @@ public class Input
         // apply a big jump from the last OS-accelerated movement.
         _accumulatedDeltaX = 0f;
         _accumulatedDeltaY = 0f;
+    }
+
+    void GatherCharacterInput()
+    {
+        var keyboard = window.KeyboardState;
+        Vector2 movement = Vector2.Zero;
+        if (keyboard.IsKeyDown(Keys.W))
+            movement += new Vector2(0, 1);
+        if (keyboard.IsKeyDown(Keys.S))
+            movement += new Vector2(0, -1);
+        if (keyboard.IsKeyDown(Keys.A))
+            movement += new Vector2(-1, 0);
+        if (keyboard.IsKeyDown(Keys.D))
+            movement += new Vector2(1, 0);
+
+        var lengthSquared = movement.LengthSquared();
+        if (lengthSquared > 1f)
+        {
+            movement /= MathF.Sqrt(lengthSquared);
+        }
+
+        var jumpDown = keyboard.IsKeyDown(Keys.Space);
+        _jumpPressed = jumpDown && !_previousJumpDown;
+        _jumpHeld = jumpDown;
+        _previousJumpDown = jumpDown;
+
+        _sprintHeld = keyboard.IsKeyDown(Keys.LeftShift) || keyboard.IsKeyDown(Keys.RightShift);
+        _movement = movement;
     }
 }
 

--- a/src/Host/InputState.cs
+++ b/src/Host/InputState.cs
@@ -1,0 +1,29 @@
+using System.Numerics;
+
+namespace RenderMaster;
+
+public enum MovementMode
+{
+    Noclip,
+    Character
+}
+
+public readonly struct InputState
+{
+    public MovementMode Mode { get; }
+    public bool CaptureActive { get; }
+    public Vector2 Movement { get; }
+    public bool JumpPressed { get; }
+    public bool JumpHeld { get; }
+    public bool SprintHeld { get; }
+
+    public InputState(MovementMode mode, bool captureActive, Vector2 movement, bool jumpPressed, bool jumpHeld, bool sprintHeld)
+    {
+        Mode = mode;
+        CaptureActive = captureActive;
+        Movement = movement;
+        JumpPressed = jumpPressed;
+        JumpHeld = jumpHeld;
+        SprintHeld = sprintHeld;
+    }
+}

--- a/src/Physics/PhysicsCallbacks.cs
+++ b/src/Physics/PhysicsCallbacks.cs
@@ -16,6 +16,10 @@ namespace RenderMaster.src.Physics
     {
         public struct narrowPhase : INarrowPhaseCallbacks
         {
+            public PlayerController? Player;
+            public BodyHandle PlayerBodyHandle;
+            public Vector3 Up;
+
             public void Initialize(Simulation simulation)
             {
                 // Optionally stash references to Simulation/BufferPool/etc.
@@ -35,7 +39,40 @@ namespace RenderMaster.src.Physics
                     frictionCoefficient: 0.01f,
                     maximumRecoveryVelocity: 2f,
                     springSettings: new SpringSettings(30f, 1f)); // (stiffness, damping)
+
+                TryCaptureSupport(pair, ref manifold);
                 return true; // create a constraint for this manifold
+            }
+
+            void TryCaptureSupport<TManifold>(CollidablePair pair, ref TManifold manifold)
+                where TManifold : unmanaged, IContactManifold<TManifold>
+            {
+                if (Player == null || manifold.Count == 0)
+                    return;
+
+                var playerHandleValue = PlayerBodyHandle.Value;
+                bool aIsPlayer = pair.A.Mobility != CollidableMobility.Static && pair.A.BodyHandle.Value == playerHandleValue;
+                bool bIsPlayer = pair.B.Mobility != CollidableMobility.Static && pair.B.BodyHandle.Value == playerHandleValue;
+
+                if (!(aIsPlayer || bIsPlayer))
+                    return;
+
+                var up = Up == default ? Vector3.UnitY : Up;
+                var slopeThreshold = Player!.CosMaximumSlope;
+
+                for (int i = 0; i < manifold.Count; i++)
+                {
+                    var normal = manifold.GetNormal(i);
+                    if (bIsPlayer)
+                        normal = -normal;
+
+                    var dot = Vector3.Dot(normal, up);
+                    if (dot >= slopeThreshold)
+                    {
+                        var depth = manifold.GetDepth(i);
+                        Player!.RegisterSupport(normal, depth);
+                    }
+                }
             }
 
             // Child-level filter (when compounds/meshes are involved). Return false to skip a particular child-child pair.

--- a/src/Physics/PhysicsEngine.cs
+++ b/src/Physics/PhysicsEngine.cs
@@ -3,32 +3,57 @@ using BepuPhysics.Collidables;
 using BepuPhysics.CollisionDetection;
 using BepuPhysics.Constraints;
 using BepuUtilities.Memory;
-using OpenTK.Windowing.Common;
 using static RenderMaster.src.Physics.PhysicsCallbacks;
 
-namespace RenderMaster.src.Physics
+namespace RenderMaster.src.Physics;
+
+class PhysicsEngine
 {
-    class PhysicsEngine
+    private readonly BufferPool _bufferPool;
+    public Simulation Simulation { get; }
+    private narrowPhase _narrowPhase;
+    private readonly poseIntegrator _poseIntegrator;
+
+    public PlayerController Player { get; }
+
+    public PhysicsEngine(System.Numerics.Vector3 initialPlayerPosition)
     {
-        private BufferPool bufferPool;
-        public Simulation simulation;
-        private narrowPhase narrowPhase = new();
-        private poseIntegrator poseIntegrator = new(new System.Numerics.Vector3(0f, -3.81f, 0f), 0.01f, 0.02f);
+        _bufferPool = new BufferPool();
+        _narrowPhase = new narrowPhase { Up = System.Numerics.Vector3.UnitY };
+        _poseIntegrator = new poseIntegrator(new System.Numerics.Vector3(0f, -9.81f, 0f), 0.01f, 0.03f);
 
-        public PhysicsEngine()
+        Simulation = Simulation.Create(_bufferPool, _narrowPhase, _poseIntegrator, new SolveDescription(velocityIterationCount: 8, substepCount: 1));
+
+        Player = new PlayerController(Simulation, initialPlayerPosition, totalHeight: 1.8f, radius: 0.35f);
+
+        _narrowPhase.Player = Player;
+        _narrowPhase.PlayerBodyHandle = Player.BodyHandle;
+        Simulation.NarrowPhase.Callbacks.Player = Player;
+        Simulation.NarrowPhase.Callbacks.PlayerBodyHandle = Player.BodyHandle;
+        Simulation.NarrowPhase.Callbacks.Up = System.Numerics.Vector3.UnitY;
+    }
+
+    public void Setup()
+    {
+        Simulation.Statics.Add(new StaticDescription(new System.Numerics.Vector3(0, -0.5f, 0), Simulation.Shapes.Add(new Box(2500, 1, 2500))));
+    }
+
+    public void Update(float deltaTime, InputState input, OpenTK.Mathematics.Vector3 cameraFront, OpenTK.Mathematics.Vector3 cameraRight)
+    {
+        var front = new System.Numerics.Vector3(cameraFront.X, cameraFront.Y, cameraFront.Z);
+        var right = new System.Numerics.Vector3(cameraRight.X, cameraRight.Y, cameraRight.Z);
+
+        if (input.Mode == MovementMode.Character && input.CaptureActive)
         {
-            bufferPool = new BufferPool();
-            simulation = Simulation.Create(bufferPool, narrowPhase, poseIntegrator, new SolveDescription(velocityIterationCount: 8, substepCount: 1));
+            Player.ApplyInput(deltaTime, input.Movement, input.SprintHeld, input.JumpPressed, front, right);
+        }
+        else
+        {
+            Player.ApplyInput(deltaTime, System.Numerics.Vector2.Zero, false, false, front, right);
         }
 
-        public void Setup()
-        {
-            simulation.Statics.Add(new StaticDescription(new System.Numerics.Vector3(0, -0.5f, 0), simulation.Shapes.Add(new Box(2500, 1, 2500))));
-        }
-
-        public void Update(FrameEventArgs args, float deltaTime)
-        {
-            // Advance simulation by the timestep. Callers can integrate other systems before or after as needed.
-        }
+        Player.BeginStep();
+        Simulation.Timestep(deltaTime);
+        Player.EndStep();
     }
 }

--- a/src/Physics/PlayerController.cs
+++ b/src/Physics/PlayerController.cs
@@ -1,0 +1,225 @@
+using BepuPhysics;
+using BepuPhysics.Collidables;
+using System.Numerics;
+
+namespace RenderMaster.src.Physics;
+
+public sealed class PlayerController
+{
+    readonly Simulation _simulation;
+    readonly BodyHandle _bodyHandle;
+    readonly TypedIndex _shapeIndex;
+    readonly float _halfLength;
+    readonly float _eyeHeight;
+
+    bool _grounded;
+    bool _supportThisStep;
+    float _bestSupportDepth;
+    Vector3 _supportNormal;
+
+    public float MaxGroundSpeed { get; set; } = 8.5f;
+    public float MaxAirSpeed { get; set; } = 8.5f;
+    public float GroundAcceleration { get; set; } = 65f;
+    public float AirAcceleration { get; set; } = 35f;
+    public float GroundFriction { get; set; } = 8.5f;
+    public float JumpSpeed { get; set; } = 7.5f;
+    public float CosMaximumSlope { get; set; } = MathF.Cos(MathF.PI * 0.45f);
+
+    public Vector3 Up => Vector3.UnitY;
+    public BodyHandle BodyHandle => _bodyHandle;
+    public bool IsGrounded => _grounded;
+    public Vector3 SupportNormal => _supportNormal;
+    public float EyeHeight => _eyeHeight;
+
+    public PlayerController(Simulation simulation, Vector3 initialPosition, float totalHeight, float radius, float mass = 80f)
+    {
+        _simulation = simulation;
+        var cylinderLength = MathF.Max(0f, totalHeight - 2f * radius);
+        _halfLength = cylinderLength * 0.5f;
+        _eyeHeight = _halfLength + radius * 0.9f;
+
+        var capsule = new Capsule(radius, cylinderLength);
+        var bodyDescription = BodyDescription.CreateDynamic(
+            new RigidPose(initialPosition),
+            new BodyInertia { InverseMass = 1f / mass },
+            new CollidableDescription(simulation.Shapes.Add(capsule), radius * 0.02f, float.MaxValue, ContinuousDetection.Passive),
+            new BodyActivityDescription(0.01f));
+
+        // Prevent the controller from tipping over when colliding with geometry.
+        bodyDescription.LocalInertia.InverseInertiaTensor = default;
+
+        _bodyHandle = simulation.Bodies.Add(bodyDescription);
+        _shapeIndex = bodyDescription.Collidable.Shape;
+
+        ref var body = ref simulation.Bodies.GetBodyReference(_bodyHandle);
+        body.Pose.Orientation = Quaternion.Identity;
+    }
+
+    public void Dispose()
+    {
+        _simulation.Shapes.Remove(_shapeIndex);
+        _simulation.Bodies.Remove(_bodyHandle);
+    }
+
+    public void TeleportToCenter(Vector3 position)
+    {
+        ref var body = ref _simulation.Bodies.GetBodyReference(_bodyHandle);
+        body.Pose.Position = position;
+        body.Pose.Orientation = Quaternion.Identity;
+        body.Velocity.Linear = Vector3.Zero;
+        body.Velocity.Angular = Vector3.Zero;
+        _grounded = false;
+    }
+
+    public void TeleportToMatchCamera(Vector3 cameraPosition)
+    {
+        var center = cameraPosition - new Vector3(0f, _eyeHeight - 0.1f, 0f);
+        TeleportToCenter(center);
+    }
+
+    public Vector3 Position
+    {
+        get
+        {
+            return _simulation.Bodies.GetBodyReference(_bodyHandle).Pose.Position;
+        }
+    }
+
+    public Vector3 EyeWorldPosition => Position + new Vector3(0f, _eyeHeight, 0f);
+
+    public void ApplyInput(float dt, Vector2 movementInput, bool sprintHeld, bool jumpPressed, Vector3 cameraForward, Vector3 cameraRight)
+    {
+        ref var body = ref _simulation.Bodies.GetBodyReference(_bodyHandle);
+        body.Awake = true;
+        body.Pose.Orientation = Quaternion.Identity;
+        body.Velocity.Angular = Vector3.Zero;
+
+        var velocity = body.Velocity.Linear;
+        var horizontalVelocity = new Vector3(velocity.X, 0f, velocity.Z);
+
+        var forward = ProjectToPlane(cameraForward);
+        var right = ProjectToPlane(cameraRight);
+
+        Vector3 desiredDirection = Vector3.Zero;
+        if (movementInput.LengthSquared() > 0f)
+        {
+            desiredDirection = forward * movementInput.Y + right * movementInput.X;
+            if (desiredDirection.LengthSquared() > 0f)
+                desiredDirection = Vector3.Normalize(desiredDirection);
+        }
+
+        var targetSpeed = MaxGroundSpeed * (sprintHeld ? 1.6f : 1f);
+        var maxAirSpeed = MaxAirSpeed * (sprintHeld ? 1.25f : 1f);
+
+        if (_grounded)
+        {
+            if (horizontalVelocity.LengthSquared() > 0f && desiredDirection == Vector3.Zero && !jumpPressed)
+            {
+                ApplyFriction(ref horizontalVelocity, GroundFriction, dt);
+            }
+
+            if (desiredDirection != Vector3.Zero)
+            {
+                Accelerate(ref horizontalVelocity, desiredDirection, targetSpeed, GroundAcceleration, dt, targetSpeed);
+            }
+
+            if (jumpPressed)
+            {
+                velocity.Y = JumpSpeed;
+                _grounded = false;
+                _supportThisStep = false;
+            }
+            else if (velocity.Y < 0f)
+            {
+                velocity.Y = MathF.Max(velocity.Y, -1f);
+            }
+        }
+        else
+        {
+            if (desiredDirection != Vector3.Zero)
+            {
+                Accelerate(ref horizontalVelocity, desiredDirection, maxAirSpeed, AirAcceleration, dt, maxAirSpeed);
+            }
+        }
+
+        velocity.X = horizontalVelocity.X;
+        velocity.Z = horizontalVelocity.Z;
+
+        body.Velocity.Linear = velocity;
+    }
+
+    static Vector3 ProjectToPlane(Vector3 v)
+    {
+        var projected = new Vector3(v.X, 0f, v.Z);
+        var lengthSquared = projected.LengthSquared();
+        if (lengthSquared < 1e-6f)
+        {
+            return Vector3.UnitX;
+        }
+
+        return projected / MathF.Sqrt(lengthSquared);
+    }
+
+    static void ApplyFriction(ref Vector3 velocity, float friction, float dt)
+    {
+        var speed = velocity.Length();
+        if (speed < 1e-6f)
+            return;
+
+        var drop = speed * friction * dt;
+        var newSpeed = MathF.Max(0f, speed - drop);
+        velocity *= newSpeed / speed;
+    }
+
+    static void Accelerate(ref Vector3 velocity, Vector3 wishDir, float wishSpeed, float acceleration, float dt, float maxSpeed)
+    {
+        if (wishSpeed <= 0f)
+            return;
+
+        var currentSpeed = Vector3.Dot(velocity, wishDir);
+        var addSpeed = wishSpeed - currentSpeed;
+        if (addSpeed <= 0f)
+            return;
+
+        var accelSpeed = acceleration * dt * wishSpeed;
+        if (accelSpeed > addSpeed)
+            accelSpeed = addSpeed;
+
+        velocity += wishDir * accelSpeed;
+
+        var horizontal = new Vector2(velocity.X, velocity.Z);
+        var horizontalSpeed = horizontal.Length();
+        if (horizontalSpeed > maxSpeed && horizontalSpeed > 0f)
+        {
+            var scale = maxSpeed / horizontalSpeed;
+            velocity.X *= scale;
+            velocity.Z *= scale;
+        }
+    }
+
+    public void BeginStep()
+    {
+        _supportThisStep = false;
+        _bestSupportDepth = float.MinValue;
+        _supportNormal = Vector3.UnitY;
+    }
+
+    public void EndStep()
+    {
+        _grounded = _supportThisStep;
+        if (!_grounded)
+        {
+            _supportNormal = Vector3.UnitY;
+        }
+    }
+
+    internal void RegisterSupport(Vector3 normal, float depth)
+    {
+        if (depth >= _bestSupportDepth)
+        {
+            _bestSupportDepth = depth;
+            _supportNormal = normal;
+        }
+        _supportThisStep = true;
+    }
+}


### PR DESCRIPTION
## Summary
- add a Bepu-powered capsule character controller that supports bunny hopping and air strafing
- split camera control into noclip and character modes with new input state tracking
- update the physics pipeline to drive the controller, hand off support contacts, and keep the camera synced when using the controller

## Testing
- `dotnet build` *(fails: `dotnet` CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8b6206e4883268b98678cb348f3b3